### PR TITLE
Switch invalid server name format

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -108,7 +108,7 @@ class TestNetHTTPS < Test::Unit::TestCase
 
   def test_get_SNI_failure
     TestNetHTTPUtils.clean_http_proxy_env do
-      http = Net::HTTP.new("invalid_servername", config("port"))
+      http = Net::HTTP.new("invalidservername", config("port"))
       http.ipaddr = config('host')
       http.use_ssl = true
       http.cert_store = TEST_STORE
@@ -204,22 +204,22 @@ class TestNetHTTPS < Test::Unit::TestCase
     skip $!
   end
 
-  def test_skip_hostname_verfiction
+  def test_skip_hostname_verification
     TestNetHTTPUtils.clean_http_proxy_env do
-      http = Net::HTTP.new('invalid_servername', config('port'))
+      http = Net::HTTP.new('invalidservername', config('port'))
       http.ipaddr = config('host')
       http.use_ssl = true
       http.cert_store = TEST_STORE
       http.verify_hostname = false
       assert_nothing_raised { http.start }
     ensure
-      http&.finish
+      http.finish if http&.started?
     end
   end
 
   def test_fail_if_verify_hostname_is_true
     TestNetHTTPUtils.clean_http_proxy_env do
-      http = Net::HTTP.new('invalid_servername', config('port'))
+      http = Net::HTTP.new('invalidservername', config('port'))
       http.ipaddr = config('host')
       http.use_ssl = true
       http.cert_store = TEST_STORE


### PR DESCRIPTION
invalid_servername is not a valid name in an SSL request due to
the use of the underscore, and LibreSSL 3.2.0 will raise an
exception for this.  These tests are not testing the allowed
characters in the server name, but how net/http handles cases where
the server name provided does not match the IP address you are
trying to connect to, so I think it's better to just modify the
tests to use a correct format.

While here, fix a typo in a test name, and use better code in the
ensure block so the same test doesn't issue both a failure and an
error.