### PR TITLE
Initialize OpenSSL early before creating TCPSocket

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -973,6 +973,12 @@ module Net   #:nodoc:
     private :do_start
 
     def connect
+      if use_ssl?
+        # reference early to load OpenSSL before connecting,
+        # as OpenSSL may take time to load.
+        @ssl_context = OpenSSL::SSL::SSLContext.new
+      end
+
       if proxy? then
         conn_addr = proxy_address
         conn_port = proxy_port
@@ -1020,7 +1026,6 @@ module Net   #:nodoc:
             end
           end
         end
-        @ssl_context = OpenSSL::SSL::SSLContext.new
         @ssl_context.set_params(ssl_parameters)
         @ssl_context.session_cache_mode =
           OpenSSL::SSL::SSLContext::SESSION_CACHE_CLIENT |


### PR DESCRIPTION
OpenSSL make take some time to initialize, and it would be best
to take that time before connecting instead of after.

From joshc on Redmine.

Fixes Ruby Bug #9459