### PR TITLE
Replace Timeout.timeout in Net:HTTP#connect

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -982,14 +982,13 @@ module Net   #:nodoc:
       end
 
       D "opening connection to #{conn_addr}:#{conn_port}..."
-      s = Timeout.timeout(@open_timeout, Net::OpenTimeout) {
-        begin
-          TCPSocket.open(conn_addr, conn_port, @local_host, @local_port)
-        rescue => e
-          raise e, "Failed to open TCP connection to " +
-            "#{conn_addr}:#{conn_port} (#{e.message})"
-        end
-      }
+      begin
+        s = Socket.tcp conn_addr, conn_port, @local_host, @local_port, connect_timeout: @open_timeout
+      rescue => e
+        e = Net::OpenTimeout.new(e) if e.is_a?(Errno::ETIMEDOUT) #for compatibility with previous versions
+        raise e, "Failed to open TCP connection to " +
+          "#{conn_addr}:#{conn_port} (#{e.message})"
+      end
       s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       D "opened"
       if use_ssl?


### PR DESCRIPTION
Use socket timeout option instead. 
See https://github.com/ruby/net-http/issues/6 for discussion