### PR TITLE
Replace "iff" with "if and only if"

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -524,7 +524,7 @@ module Net   #:nodoc:
     #
     #   { "cmd" => "search", "q" => "ruby", "max" => "50" }
     #
-    # This method also does Basic Authentication iff +url+.user exists.
+    # This method also does Basic Authentication if and only if +url+.user exists.
     # But userinfo for authentication is deprecated (RFC3986).
     # So this feature will be removed.
     #


### PR DESCRIPTION
iff means if and only if, but readers without that knowledge might
assume this to be a spelling mistake. To me, this seems like
exclusionary language that is unnecessary. Simply using "if and only if"
instead should suffice.

net-http changes from https://github.com/ruby/ruby/pull/4035