### PR TITLE
We don't need "require 'uri'" after "require 'net/http'".

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -531,7 +531,6 @@ module Net   #:nodoc:
     # Example:
     #
     #   require 'net/http'
-    #   require 'uri'
     #
     #   Net::HTTP.post_form URI('http://www.example.com/search.cgi'),
     #                       { "q" => "ruby", "max" => "50" }


### PR DESCRIPTION
ruby/ruby@ee1e690a2df901adb279d7a63fbd92c64e0a5ae6