### PR TITLE
Fix a warning

### DIFF
--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -78,7 +78,7 @@ EOS
 
   def test_read_body_block_mod
     # http://ci.rvm.jp/results/trunk-mjit-wait@silicon-docker/3019353
-    if defined?(RubyVM::JIT) && RubyVM::JIT.enabled? || defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
+    if defined?(RubyVM::JIT) ? RubyVM::JIT.enabled? : defined?(RubyVM::MJIT) && RubyVM::MJIT.enabled?
       skip 'too unstable with --jit-wait, and extending read_timeout did not help it'
     end
     IO.pipe do |r, w|


### PR DESCRIPTION
```
.../ruby/test/net/http/test_httpresponse.rb:81: warning: constant RubyVM::MJIT is deprecated
```

ruby/ruby@9de68a522138