### PR TITLE
Update the content-length heading when decoding bodies

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -263,6 +263,7 @@ class Net::HTTPResponse
     case v&.downcase
     when 'deflate', 'gzip', 'x-gzip' then
       self.delete 'content-encoding'
+      had_content_length = self.delete 'content-length'
 
       inflate_body_io = Inflater.new(@socket)
 
@@ -272,6 +273,9 @@ class Net::HTTPResponse
       ensure
         begin
           inflate_body_io.finish
+          if had_content_length
+            self['content-length'] = inflate_body_io.bytes_inflated.to_s
+          end
         rescue => err
           # Ignore #finish's error if there is an exception from yield
           raise err if success
@@ -371,6 +375,14 @@ class Net::HTTPResponse
     def finish
       return if @inflate.total_in == 0
       @inflate.finish
+    end
+
+    ##
+    # The number of bytes inflated, used to update the Content-Length of
+    # the response.
+
+    def bytes_inflated
+      @inflate.total_out
     end
 
     ##

--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -127,9 +127,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal '5', res['content-length']
       assert_equal 'hello', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal '13', res['content-length']
       assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15", body
     end
   end
@@ -155,9 +157,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal '5', res['content-length']
       assert_equal 'hello', body
     else
       assert_equal 'DEFLATE', res['content-encoding']
+      assert_equal '13', res['content-length']
       assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15", body
     end
   end
@@ -188,9 +192,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal 'hello', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15", body
     end
   end
@@ -215,6 +221,7 @@ EOS
     end
 
     assert_equal 'deflate', res['content-encoding'], 'Bug #7831'
+    assert_equal '13', res['content-length']
     assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15", body, 'Bug #7381'
   end
 
@@ -238,9 +245,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal 'hello', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15\r\n", body
     end
   end
@@ -288,9 +297,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal '0', res['content-length']
       assert_equal '', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal '0', res['content-length']
       assert_equal '', body
     end
   end
@@ -314,9 +325,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal '', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal '', body
     end
   end


### PR DESCRIPTION
Previously, the content-encoding header was removed and the body
was modified, but the content-length header was not modified,
resulting in the content-length header not matching the body
length.

Fixes [Bug #16672]