### PR TITLE
Fix the regexp used to clean the host

### DIFF
--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -143,7 +143,7 @@ class Net::HTTPGenericRequest
     end
 
     if host = self['host']
-      host.sub!(/:.*/s, ''.freeze)
+      host.sub!(/:.*/m, ''.freeze)
     elsif host = @uri.host
     else
      host = addr


### PR DESCRIPTION
I noticed this regexp because of the crash reported in https://github.com/ruby/ruby/pull/4119#issuecomment-800189841

Introduced in https://github.com/ruby/ruby/commit/c1652035644

`/s` marks the regexp as encoded with Windows-31J which makes little
sense.

[Nurse thinks the intent was to use `/m` for a multi-line regexp](https://github.com/ruby/ruby/pull/4286#issuecomment-802289641)

