### PR TITLE
Do not require stringio

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -393,7 +393,6 @@ module Net   #:nodoc:
     HTTPVersion = '1.1'
     begin
       require 'zlib'
-      require 'stringio'  #for our purposes (unpacking gzip) lump these together
       HAVE_ZLIB=true
     rescue LoadError
       HAVE_ZLIB=false

--- a/test/net/http/test_http_request.rb
+++ b/test/net/http/test_http_request.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: false
 require 'net/http'
 require 'test/unit'
-require 'stringio'
 
 class HTTPRequestTest < Test::Unit::TestCase
 

--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: false
 require "test/unit"
+require_relative "utils"
 begin
   require 'net/https'
-  require 'stringio'
-  require 'timeout'
-  require File.expand_path("utils", File.dirname(__FILE__))
 rescue LoadError
   # should skip this test
 end


### PR DESCRIPTION
It is not used in net/http library code since commit 15ccd0118c13 (r36473 in ruby svn trunk, 2012).

require's in test suite are also cleaned up.