### PR TITLE
Add path and headers to Request inspect method

### DIFF
--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -99,7 +99,7 @@ class Net::HTTPGenericRequest
   #   Net::HTTP::Post.new(uri).inspect # => "#<Net::HTTP::Post POST>"
   #
   def inspect
-    "\#<#{self.class} #{@method}>"
+    "\#<#{self.class} #{@method} path=#{@path.inspect} headers=#{to_hash.inspect}>"
   end
 
   ##


### PR DESCRIPTION
I find having the path and headers when inspecting a request to be handy.

```
>> Net::HTTP::Get.new "/"
=> #<Net::HTTP::Get GET path="/" headers={"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"], "accept"=>["*/*"], "user-agent"=>["Ruby"]}>
```