### PR TITLE
gemspec: Drop unused directive "executables"

### DIFF
--- a/net-http.gemspec
+++ b/net-http.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
     `git ls-files -z 2>/dev/null`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"


### PR DESCRIPTION
This gem exposes no executable files.