### PR TITLE
Handle invalid use of IP addresses in SNI

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -255,7 +255,7 @@ class TestNetHTTPS < Test::Unit::TestCase
     ex = assert_raise(OpenSSL::SSL::SSLError){
       http.request_get("/") {|res| }
     }
-    re_msg = /certificate verify failed|hostname \"#{HOST_IP}\" does not match/
+    re_msg = /certificate verify failed|hostname \"#{HOST_IP}\" does not match|ssl3 ext invalid servername/
     assert_match(re_msg, ex.message)
   end
 


### PR DESCRIPTION
Server Name Indication does not allow IP addresses (RFC 6066, section 3:
`Literal IPv4 and IPv6 addresses are not permitted in "HostName".`).

Recent versions of LibreSSL enforce this restriction, which raises
when setting the hostname to an IP address (s.hostname=), before
attempting to setup the SSL connection.

Since the certificate used in the test is already for localhost,
we cannot connect to localhost.  However, as all the test does is
check for a specific exception, just modify the regexp used so it
handles both cases.