### PR TITLE
Do not set SNI hostname if connecting to IP address

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -255,7 +255,7 @@ class TestNetHTTPS < Test::Unit::TestCase
     ex = assert_raise(OpenSSL::SSL::SSLError){
       http.request_get("/") {|res| }
     }
-    re_msg = /certificate verify failed|hostname \"#{HOST_IP}\" does not match|ssl3 ext invalid servername/
+    re_msg = /certificate verify failed|hostname \"#{HOST_IP}\" does not match/
     assert_match(re_msg, ex.message)
   end
 


### PR DESCRIPTION
RFC 6066, section 3, explicitly disallows the use of an IP address
as an SNI server name.  So check if the connection is being made
to an IP address using the resolv regexps, and do not set an SNI
hostname in that case.

Note that this results in a warning in the tests, but that is due
to an issue in the openssl extension.  A pull request has been
submitted to the openssl extension to remove that warning.

Revert the previous change that modified the regexp used for
checking the error message.

This not only fixes net/http tests, it also fixes tests for
webrick and open-uri when used with recent LibreSSL , which both make SSL connections to 127.0.0.1
in their tests.