### PR TITLE
Ignore EBADF when closing a socket after exception

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1078,7 +1078,10 @@ module Net   #:nodoc:
     rescue => exception
       if s
         debug "Conn close because of connect error #{exception}"
-        s.close
+        begin
+          s.close
+        rescue Errno::EBADF #Sometimes thrown on JRuby
+        end  
       end
       raise
     end


### PR DESCRIPTION
On JRuby, Errno::EBADF is thrown sometimes when trying to close the socket after an exception has occurred. This change ignores that so that the original exception can be raised