### PR TITLE
Set correct uplevel to warning on supply_default_content_type

### DIFF
--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -298,7 +298,10 @@ class Net::HTTPGenericRequest
 
   def supply_default_content_type
     return if content_type()
-    warn 'net/http: Content-Type did not set; using application/x-www-form-urlencoded', uplevel: 1 if $VERBOSE
+    if $VERBOSE
+      uplevel = caller_locations.find_index { |loc| not loc.absolute_path.match?(%r!net/http!) } || 0
+      warn 'net/http: Content-Type did not set; using application/x-www-form-urlencoded', uplevel: uplevel+1
+    end
     set_content_type 'application/x-www-form-urlencoded'
   end
 


### PR DESCRIPTION
This PR fixes uplevel of `supply_default_content_type`.

# Problem 


Currently `supply_default_content_type` specifies an incorrect `uplevel` to `warn` method.
For example:


```ruby
require 'net/http'

url = URI.parse('http://www.example.com/index.html')
req = Net::HTTP::Post.new(url.path)
res = Net::HTTP.start(url.host, url.port) {|http|
  http.request(req)
}
res.body
```

```console
$ ruby test.rb
/Users/kuwabara.masataka/.rbenv/versions/trunk/lib/ruby/3.2.0+0/net/http/generic_request.rb:186: warning: net/http: Content-Type did not set; using application/x-www-form-urlencoded
```


The warning points to `net/http/generic_request.rb` which is not written by the user. The location is not helpful to fix the warning by the user.



# Solution


Find the correct `uplevel` from the caller and specify it.

I also considered using a fixed `uplevel` for it, like `uplevel: 6`. But I think `caller_location` is better than the fixed value.
Because the `uplevel` is too deep, and `supply_default_content_type` is called from multiple places so the fixed value doesn't work properly for all callers perhaps.

