### PR TITLE
Don't delete content-length before yielding inflate body

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -263,7 +263,6 @@ class Net::HTTPResponse
     case v&.downcase
     when 'deflate', 'gzip', 'x-gzip' then
       self.delete 'content-encoding'
-      had_content_length = self.delete 'content-length'
 
       inflate_body_io = Inflater.new(@socket)
 
@@ -273,7 +272,7 @@ class Net::HTTPResponse
       ensure
         begin
           inflate_body_io.finish
-          if had_content_length
+          if self['content-length']
             self['content-length'] = inflate_body_io.bytes_inflated.to_s
           end
         rescue => err


### PR DESCRIPTION
Fixes #49 

**result when running the same repro script**

```
❯ time ruby -Ilib -rnet/http -rdebug -e "puts Net::HTTP.get(URI.parse('https://raw.githubusercontent.com/ruby/debug/master/.gitignore'))"
/.bundle/
/.yardoc
/_yardoc/
/coverage/
/doc/
/pkg/
/spec/reports/
/tmp/
*.bundle
/Gemfile.lock
/lib/debug/debug.so
.ruby-version
/debugAdapterProtocol.json
/chromeDevToolsProtocol.json
ruby -Ilib -rnet/http -rdebug -e   0.24s user 0.10s system 57% cpu 0.606 total
```

The `content-length` information is still needed when evaluating the given block. Removing it before that will make `read_body_0` switch from `@socket.read length` to `@socket.read_all`, which can take very long and cause timeout.

I'm not sure how to reproduce the issue with tests though.