### PR TITLE
Update the content-length heading when decoding bodies

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -272,6 +272,9 @@ class Net::HTTPResponse
       ensure
         begin
           inflate_body_io.finish
+          if self['content-length']
+            self['content-length'] = inflate_body_io.bytes_inflated.to_s
+          end
         rescue => err
           # Ignore #finish's error if there is an exception from yield
           raise err if success
@@ -371,6 +374,14 @@ class Net::HTTPResponse
     def finish
       return if @inflate.total_in == 0
       @inflate.finish
+    end
+
+    ##
+    # The number of bytes inflated, used to update the Content-Length of
+    # the response.
+
+    def bytes_inflated
+      @inflate.total_out
     end
 
     ##

--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -127,9 +127,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal '5', res['content-length']
       assert_equal 'hello', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal '13', res['content-length']
       assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15", body
     end
   end
@@ -155,9 +157,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal '5', res['content-length']
       assert_equal 'hello', body
     else
       assert_equal 'DEFLATE', res['content-encoding']
+      assert_equal '13', res['content-length']
       assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15", body
     end
   end
@@ -188,9 +192,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal 'hello', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15", body
     end
   end
@@ -215,6 +221,7 @@ EOS
     end
 
     assert_equal 'deflate', res['content-encoding'], 'Bug #7831'
+    assert_equal '13', res['content-length']
     assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15", body, 'Bug #7381'
   end
 
@@ -238,9 +245,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal 'hello', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal "x\x9C\xCBH\xCD\xC9\xC9\a\x00\x06,\x02\x15\r\n", body
     end
   end
@@ -288,9 +297,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal '0', res['content-length']
       assert_equal '', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal '0', res['content-length']
       assert_equal '', body
     end
   end
@@ -314,9 +325,11 @@ EOS
 
     if Net::HTTP::HAVE_ZLIB
       assert_equal nil, res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal '', body
     else
       assert_equal 'deflate', res['content-encoding']
+      assert_equal nil, res['content-length']
       assert_equal '', body
     end
   end


### PR DESCRIPTION
Previously, the content-encoding header was removed and the body
was modified, but the content-length header was not modified,
resulting in the content-length header not matching the body
length.

Don't delete content-length before yielding inflate body, as that
causes a switch to read the entire body instead of reading in
chunks.  I checked that this approach passes Ruby CI, where the
previous approach failed:

* https://github.com/jeremyevans/ruby/runs/5823979744
* https://github.com/jeremyevans/ruby/runs/5823979601

Fixes [Bug #16672]

Co-authored-by: st0012 <stan001212@gmail.com>