### PR TITLE
feature detect to make net/http usable with JRuby

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1033,9 +1033,11 @@ module Net   #:nodoc:
           end
         end
         @ssl_context.set_params(ssl_parameters)
-        @ssl_context.session_cache_mode =
-          OpenSSL::SSL::SSLContext::SESSION_CACHE_CLIENT |
-          OpenSSL::SSL::SSLContext::SESSION_CACHE_NO_INTERNAL_STORE
+        unless @ssl_context.session_cache_mode.nil? # a dummy method on JRuby
+          @ssl_context.session_cache_mode =
+              OpenSSL::SSL::SSLContext::SESSION_CACHE_CLIENT |
+                  OpenSSL::SSL::SSLContext::SESSION_CACHE_NO_INTERNAL_STORE
+        end
         if @ssl_context.respond_to?(:session_new_cb) # not implemented under JRuby
           @ssl_context.session_new_cb = proc {|sock, sess| @ssl_session = sess }
         end

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1036,7 +1036,9 @@ module Net   #:nodoc:
         @ssl_context.session_cache_mode =
           OpenSSL::SSL::SSLContext::SESSION_CACHE_CLIENT |
           OpenSSL::SSL::SSLContext::SESSION_CACHE_NO_INTERNAL_STORE
-        @ssl_context.session_new_cb = proc {|sock, sess| @ssl_session = sess }
+        if @ssl_context.respond_to?(:session_new_cb) # not implemented under JRuby
+          @ssl_context.session_new_cb = proc {|sock, sess| @ssl_session = sess }
+        end
 
         # Still do the post_connection_check below even if connecting
         # to IP address

--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -152,12 +152,14 @@ class TestNetHTTPS < Test::Unit::TestCase
     end
 
     http.start
-    assert_equal false, http.instance_variable_get(:@socket).io.session_reused?
+    session_reused = http.instance_variable_get(:@socket).io.session_reused?
+    assert_false session_reused unless session_reused.nil? # can not detect re-use under JRuby
     http.get("/")
     http.finish
 
     http.start
-    assert_equal true, http.instance_variable_get(:@socket).io.session_reused?
+    session_reused = http.instance_variable_get(:@socket).io.session_reused?
+    assert_true session_reused unless session_reused.nil? # can not detect re-use under JRuby
     assert_equal $test_net_http_data, http.get("/").body
     http.finish
   end
@@ -301,7 +303,7 @@ class TestNetHTTPS < Test::Unit::TestCase
     ex = assert_raise(OpenSSL::SSL::SSLError){
       http.request_get("/") {|res| }
     }
-    re_msg = /\ASSL_connect returned=1 errno=0 |SSL_CTX_set_max_proto_version/
+    re_msg = /\ASSL_connect returned=1 errno=0 |SSL_CTX_set_max_proto_version|No appropriate protocol/
     assert_match(re_msg, ex.message)
   end
 


### PR DESCRIPTION
up till JRuby 9.3 (Ruby 2.6 compatibility) JRuby shipped a slightly patched version of net/http to work-around some of the limitations - mostly of JRuby-OpenSSL which is implemented on top of Java APIs (does not use OpenSSL).

for JRuby 9.4, which is in development atm, it would be nice to be able to ship the gem version of net/http - the changes here represent an effort to make things compatible, there's really one important change:

- `SSLContext#session_new_cb` in not implemented under JRuby, it could be a dummy no-op but this would confuse users as these session_xxx callbacks do not get actually called (no way to hook into session management on the Java SSL engine end)
- `SSLContext#session_cache_mode=` historically exist in JRuby but is effectively a no-op and issues a `Kernel.warn`, the `SSLContext#session_cache_mode` reader always returns `nil` as an attempt to be able to "feature-detect"
- also looked into low hanging fruit in some of the tests (with these there's only 3 failures left under JRuby)