### PR TITLE
Make `Net::HTTPHeader#content_range` return nil on non-byte units

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -338,9 +338,10 @@ module Net::HTTPHeader
   # fits inside the full entity body, as range of byte offsets.
   def content_range
     return nil unless @header['content-range']
-    m = %r<bytes\s+(\d+)-(\d+)/(\d+|\*)>i.match(self['Content-Range']) or
+    m = %r<\A\s*(\w+)\s+(\d+)-(\d+)/(\d+|\*)>.match(self['Content-Range']) or
         raise Net::HTTPHeaderSyntaxError, 'wrong Content-Range format'
-    m[1].to_i .. m[2].to_i
+    return unless m[1] == 'bytes'
+    m[2].to_i .. m[3].to_i
   end
 
   # The length of the range represented in Content-Range: header.

--- a/test/net/http/test_httpheader.rb
+++ b/test/net/http/test_httpheader.rb
@@ -308,6 +308,18 @@ class HTTPHeaderTest < Test::Unit::TestCase
   end
 
   def test_content_range
+    @c['Content-Range'] = "bytes 0-499/1000"
+    assert_equal 0..499, @c.content_range
+    @c['Content-Range'] = "bytes 1-500/1000"
+    assert_equal 1..500, @c.content_range
+    @c['Content-Range'] = "bytes 1-1/1000"
+    assert_equal 1..1, @c.content_range
+    @c['Content-Range'] = "tokens 1-1/1000"
+    assert_equal nil, @c.content_range
+
+    try_invalid_content_range "invalid"
+    try_invalid_content_range "bytes 123-abc"
+    try_invalid_content_range "bytes abc-123"
   end
 
   def test_range_length
@@ -317,6 +329,15 @@ class HTTPHeaderTest < Test::Unit::TestCase
     assert_equal 500, @c.range_length
     @c['Content-Range'] = "bytes 1-1/1000"
     assert_equal 1, @c.range_length
+    @c['Content-Range'] = "tokens 1-1/1000"
+    assert_equal nil, @c.range_length
+
+    try_invalid_content_range "bytes 1-1/abc"
+  end
+
+  def try_invalid_content_range(s)
+    @c['Content-Range'] = "#{s}"
+    assert_raise(Net::HTTPHeaderSyntaxError, s){ @c.content_range }
   end
 
   def test_chunked?


### PR DESCRIPTION
* Returning nil from the `content_range` method instead of raising an error when the unit in the content-range header is not "bytes".

Fix https://bugs.ruby-lang.org/issues/11450

Co-Authored-By: Nobuyoshi Nakada <nobu@ruby-lang.org>