### PR TITLE
Fix no_proxy behaviour

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -664,7 +664,7 @@ module Net   #:nodoc:
       elsif p_addr == :ENV then
         http.proxy_from_env = true
       else
-        if p_addr && p_no_proxy && !URI::Generic.use_proxy?(p_addr, p_addr, p_port, p_no_proxy)
+        if p_addr && p_no_proxy && !URI::Generic.use_proxy?(address, address, port, p_no_proxy)
           p_addr = nil
           p_port = nil
         end

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -126,10 +126,10 @@ class TestNetHTTP < Test::Unit::TestCase
 
   def test_proxy_address_no_proxy
     TestNetHTTPUtils.clean_http_proxy_env do
-      http = Net::HTTP.new 'hostname.example', nil, 'proxy.example', nil, nil, nil, 'example'
+      http = Net::HTTP.new 'hostname.example', nil, 'proxy.com', nil, nil, nil, 'example'
       assert_nil http.proxy_address
 
-      http = Net::HTTP.new '10.224.1.1', nil, 'proxy.example', nil, nil, nil, 'example,10.224.0.0/22'
+      http = Net::HTTP.new '10.224.1.1', nil, 'proxy.com', nil, nil, nil, 'example,10.224.0.0/22'
       assert_nil http.proxy_address
     end
   end


### PR DESCRIPTION
As discussed on [this stackoverflow thread](https://superuser.com/questions/944958/are-http-proxy-https-proxy-and-no-proxy-environment-variables-standard), the `no_proxy` environment variable defines a list of hosts, for which the proxy should be bypassed.
The same semantics should probably apply to the `p_no_proxy` parameter of `Net::HTTP` class.

At the moment, this method parameter seems to be misinterpreted as a list of proxies that should not be used.

This behaviour was not detected by the existing testcase, because both the destination hostname and the proxy hostname matched the given exclusion suffix.

It might seem surprising that this problem was not detected before, given the long history of the project.
However, the problem only occurs when the proxy is explicitly configured with `Net::HTTP.new(...)``, but not when using the environment variables. 