### PR TITLE
Enable frozen_string_literal

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # = net/http.rb
 #
@@ -1028,7 +1028,7 @@ module Net   #:nodoc:
                                       write_timeout: @write_timeout,
                                       continue_timeout: @continue_timeout,
                                       debug_output: @debug_output)
-          buf = "CONNECT #{conn_address}:#{@port} HTTP/#{HTTPVersion}\r\n"
+          buf = +"CONNECT #{conn_address}:#{@port} HTTP/#{HTTPVersion}\r\n"
           buf << "Host: #{@address}:#{@port}\r\n"
           if proxy_user
             credential = ["#{proxy_user}:#{proxy_pass}"].pack('m0')

--- a/lib/net/http/backward.rb
+++ b/lib/net/http/backward.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # for backward compatibility
 
 # :enddoc:

--- a/lib/net/http/exceptions.rb
+++ b/lib/net/http/exceptions.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 module Net
   # Net::HTTP exception class.
   # You cannot use Net::HTTPExceptions directly; instead, you must use

--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # HTTPGenericRequest is the parent of the Net::HTTPRequest class.
 # Do not use this directly; use a subclass of Net::HTTPRequest.
 #
@@ -110,7 +110,7 @@ class Net::HTTPGenericRequest
     raise ArgumentError, "both of body argument and HTTPRequest#body set" if str and (@body or @body_stream)
     self.body = str if str
     if @body.nil? && @body_stream.nil? && @body_data.nil? && request_body_permitted?
-      self.body = ''
+      self.body = +''
     end
   end
 
@@ -239,7 +239,7 @@ class Net::HTTPGenericRequest
     boundary ||= SecureRandom.urlsafe_base64(40)
     chunked_p = chunked?
 
-    buf = ''
+    buf = +''
     params.each do |key, value, h={}|
       key = quote_string(key, charset)
       filename =
@@ -324,7 +324,7 @@ class Net::HTTPGenericRequest
     if /[\r\n]/ =~ reqline
       raise ArgumentError, "A Request-Line must not contain CR or LF"
     end
-    buf = ""
+    buf = +""
     buf << reqline << "\r\n"
     each_capitalized do |k,v|
       buf << "#{k}: #{v}\r\n"

--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # The HTTPHeader module defines methods for reading and writing
 # HTTP headers.
 #

--- a/lib/net/http/proxy_delta.rb
+++ b/lib/net/http/proxy_delta.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 module Net::HTTP::ProxyDelta   #:nodoc: internal use only
   private
 

--- a/lib/net/http/request.rb
+++ b/lib/net/http/request.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # HTTP request class.
 # This class wraps together the request header and the request path.
 # You cannot use this class directly. Instead, you should use one of its

--- a/lib/net/http/requests.rb
+++ b/lib/net/http/requests.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # HTTP/1.1 methods --- RFC2616
 #

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # HTTP response class.
 #
 # This class wraps together the response header and the response body (the
@@ -513,7 +513,7 @@ class Net::HTTPResponse
     if block
       Net::ReadAdapter.new(block)
     else
-      dest || ''
+      dest || +''
     end
   end
 

--- a/lib/net/https.rb
+++ b/lib/net/https.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 =begin
 
 = net/https -- SSL/TLS enhancement for Net::HTTP.

--- a/test/net/http/test_buffered_io.rb
+++ b/test/net/http/test_buffered_io.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'test/unit'
 require 'net/http'
 require 'stringio'

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -1,5 +1,5 @@
 # coding: US-ASCII
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'test/unit'
 require 'net/http'
 require 'stringio'
@@ -362,7 +362,7 @@ module TestNetHTTP_version_1_1_methods
   end
 
   def _test_get__iter(http)
-    buf = ''
+    buf = +''
     res = http.get('/') {|s| buf << s }
     assert_kind_of Net::HTTPResponse, res
     # assert_kind_of String, res.body
@@ -378,7 +378,7 @@ module TestNetHTTP_version_1_1_methods
   end
 
   def _test_get__chunked(http)
-    buf = ''
+    buf = +''
     res = http.get('/') {|s| buf << s }
     assert_kind_of Net::HTTPResponse, res
     # assert_kind_of String, res.body
@@ -685,7 +685,7 @@ module TestNetHTTP_version_1_2_methods
         assert_not_nil res['content-length']
         assert_equal $test_net_http_data.size, res['content-length'].to_i
       end
-      f = StringIO.new("".force_encoding("ASCII-8BIT"))
+      f = StringIO.new("".b)
       res.read_body f
       assert_equal $test_net_http_data.bytesize, f.string.bytesize
       assert_equal $test_net_http_data.encoding, f.string.encoding
@@ -828,7 +828,7 @@ module TestNetHTTP_version_1_2_methods
       data = [
         ['name', 'Gonbei Nanashi'],
         ['name', "\u{540d}\u{7121}\u{3057}\u{306e}\u{6a29}\u{5175}\u{885b}"],
-        ['s"i\o', StringIO.new("\u{3042 3044 4e9c 925b}")],
+        ['s"i\o', StringIO.new(+"\u{3042 3044 4e9c 925b}")],
         ["file", file, filename: "ruby-test"]
       ]
       expected = <<"__EOM__".gsub(/\n/, "\r\n")
@@ -990,7 +990,7 @@ class TestNetHTTPContinue < Test::Unit::TestCase
   include TestNetHTTPUtils
 
   def logfile
-    @debug = StringIO.new('')
+    @debug = StringIO.new(+'')
   end
 
   def mount_proc(&block)
@@ -1090,7 +1090,7 @@ class TestNetHTTPSwitchingProtocols < Test::Unit::TestCase
   include TestNetHTTPUtils
 
   def logfile
-    @debug = StringIO.new('')
+    @debug = StringIO.new(+'')
   end
 
   def mount_proc(&block)

--- a/test/net/http/test_http_request.rb
+++ b/test/net/http/test_http_request.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'net/http'
 require 'test/unit'
 

--- a/test/net/http/test_httpheader.rb
+++ b/test/net/http/test_httpheader.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'net/http'
 require 'test/unit'
 

--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -1,5 +1,5 @@
 # coding: US-ASCII
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'net/http'
 require 'test/unit'
 require 'stringio'
@@ -189,12 +189,12 @@ EOS
       body = res.read_body
     end
 
-    assert_equal "hello\u1234".force_encoding("ISO-8859-1"), body
+    assert_equal (+"hello\u1234").force_encoding("ISO-8859-1"), body
     assert_equal Encoding::ISO_8859_1, body.encoding
   end
 
   def test_read_body_body_encoding_true_with_utf8_meta_charset
-    res_body = "<html><meta charset=\"utf-8\">hello\u1234</html>"
+    res_body = +"<html><meta charset=\"utf-8\">hello\u1234</html>"
     io = dummy_io(<<EOS)
 HTTP/1.1 200 OK
 Connection: close
@@ -218,7 +218,7 @@ EOS
   end
 
   def test_read_body_body_encoding_true_with_iso8859_1_meta_charset
-    res_body = "<html><meta charset=\"iso-8859-1\">hello\u1234</html>"
+    res_body = +"<html><meta charset=\"iso-8859-1\">hello\u1234</html>"
     io = dummy_io(<<EOS)
 HTTP/1.1 200 OK
 Connection: close
@@ -242,7 +242,7 @@ EOS
   end
 
   def test_read_body_body_encoding_true_with_utf8_meta_content_charset
-    res_body = "<meta http-equiv='content-type' content='text/html; charset=UTF-8'>hello\u1234</html>"
+    res_body = +"<meta http-equiv='content-type' content='text/html; charset=UTF-8'>hello\u1234</html>"
     io = dummy_io(<<EOS)
 HTTP/1.1 200 OK
 Connection: close
@@ -266,7 +266,7 @@ EOS
   end
 
   def test_read_body_body_encoding_true_with_iso8859_1_meta_content_charset
-    res_body = "<meta http-equiv='content-type' content='text/html; charset=ISO-8859-1'>hello\u1234</html>"
+    res_body = +"<meta http-equiv='content-type' content='text/html; charset=ISO-8859-1'>hello\u1234</html>"
     io = dummy_io(<<EOS)
 HTTP/1.1 200 OK
 Connection: close
@@ -300,7 +300,7 @@ EOS
 
     res = Net::HTTPResponse.read_new(io)
 
-    body = ''
+    body = +''
 
     res.reading_body io, true do
       res.read_body do |chunk|
@@ -580,7 +580,7 @@ EOS
 
     res = Net::HTTPResponse.read_new(io)
 
-    body = ''
+    body = +''
 
     res.reading_body io, true do
       res.read_body body
@@ -704,7 +704,7 @@ EOS
     assert_equal '#<Net::HTTPUnknownResponse ??? test response readbody=false>', res.inspect
 
     res = Net::HTTPUnknownResponse.new('1.0', '???', 'test response')
-    socket = Net::BufferedIO.new(StringIO.new('test body'))
+    socket = Net::BufferedIO.new(StringIO.new(+'test body'))
     res.reading_body(socket, true) {}
     assert_equal '#<Net::HTTPUnknownResponse ??? test response readbody=true>', res.inspect
   end

--- a/test/net/http/test_httpresponses.rb
+++ b/test/net/http/test_httpresponses.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'net/http'
 require 'test/unit'
 

--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require "test/unit"
 require_relative "utils"
 begin

--- a/test/net/http/test_https_proxy.rb
+++ b/test/net/http/test_https_proxy.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 begin
   require 'net/https'
 rescue LoadError

--- a/test/net/http/utils.rb
+++ b/test/net/http/utils.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'webrick'
 begin
   require "webrick/https"


### PR DESCRIPTION
Net::HTTP contain quite a few string literals that would benefit from being interned.
