### PR TITLE
Remove ENVIRONMENT_VARIABLE_IS_MULTIUSER_SAFE

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1221,16 +1221,9 @@ module Net   #:nodoc:
       end
     end
 
-    # [Bug #12921]
-    if /linux|freebsd|darwin/ =~ RUBY_PLATFORM
-      ENVIRONMENT_VARIABLE_IS_MULTIUSER_SAFE = true
-    else
-      ENVIRONMENT_VARIABLE_IS_MULTIUSER_SAFE = false
-    end
-
     # The username of the proxy server, if one is configured.
     def proxy_user
-      if ENVIRONMENT_VARIABLE_IS_MULTIUSER_SAFE && @proxy_from_env
+      if @proxy_from_env
         user = proxy_uri&.user
         unescape(user) if user
       else
@@ -1240,7 +1233,7 @@ module Net   #:nodoc:
 
     # The password of the proxy server, if one is configured.
     def proxy_pass
-      if ENVIRONMENT_VARIABLE_IS_MULTIUSER_SAFE && @proxy_from_env
+      if @proxy_from_env
         pass = proxy_uri&.password
         unescape(pass) if pass
       else

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -178,13 +178,8 @@ class TestNetHTTP < Test::Unit::TestCase
       http = Net::HTTP.new 'hostname.example'
 
       assert_equal true, http.proxy?
-      if Net::HTTP::ENVIRONMENT_VARIABLE_IS_MULTIUSER_SAFE
-        assert_equal 'foo', http.proxy_user
-        assert_equal 'bar', http.proxy_pass
-      else
-        assert_nil http.proxy_user
-        assert_nil http.proxy_pass
-      end
+      assert_equal 'foo', http.proxy_user
+      assert_equal 'bar', http.proxy_pass
     end
   end
 
@@ -195,13 +190,8 @@ class TestNetHTTP < Test::Unit::TestCase
       http = Net::HTTP.new 'hostname.example'
 
       assert_equal true, http.proxy?
-      if Net::HTTP::ENVIRONMENT_VARIABLE_IS_MULTIUSER_SAFE
-        assert_equal "Y\\X", http.proxy_user
-        assert_equal "R%S] ?X", http.proxy_pass
-      else
-        assert_nil http.proxy_user
-        assert_nil http.proxy_pass
-      end
+      assert_equal "Y\\X", http.proxy_user
+      assert_equal "R%S] ?X", http.proxy_pass
     end
   end
 


### PR DESCRIPTION
This list is out of date.  At least OpenBSD since 2013 does not
allow one user to read the environment variables of a process
run by another user.

While we could try to keep the list updated, I think it's a bad
idea to not use the user/password from the environment, even if
another user on the system could read it.  If http_proxy exists
in the environment, and other users can read it, it doesn't
make it more secure for Ruby to ignore it.  You could argue that
it encourages poor security practices, but net/http should provide
mechanism, not policy.

Fixes [Bug #18908]