### PR TITLE
add java as a valid RUBY_PLATFORM 

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1222,7 +1222,7 @@ module Net   #:nodoc:
     end
 
     # [Bug #12921]
-    if /linux|freebsd|darwin/ =~ RUBY_PLATFORM
+    if /linux|freebsd|darwin|java/ =~ RUBY_PLATFORM
       ENVIRONMENT_VARIABLE_IS_MULTIUSER_SAFE = true
     else
       ENVIRONMENT_VARIABLE_IS_MULTIUSER_SAFE = false


### PR DESCRIPTION
jruby users are not able to use env variable to setup proxy with basic authentication because the RUBY_PLATFORM does not allow `java`.
The commit includes `java` as a valid platform.

### expected behaviour 
1. export JRUBY_OPTS='-J-Dhttps.proxyHost=user:pw@host -J-Dhttps.proxyPort=3128 -J-Dhttp.proxyHost=user:pw@host -J-Dhttp.proxyPort=3128'
2. ruby -e "require 'net/http'; uri = URI('https://www.google.com'); Net::HTTP.get(uri);"
3. no error is thrown

Fixed: #68