### PR TITLE
Net::HTTPResponse nil checking

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -231,6 +231,7 @@ class Net::HTTPResponse
       @body = nil
     end
     @read = true
+    return if @body.nil?
 
     case enc = @body_encoding
     when Encoding, false, nil
@@ -504,7 +505,7 @@ class Net::HTTPResponse
   end
 
   def stream_check
-    raise IOError, 'attempt to read body out of block' if @socket.closed?
+    raise IOError, 'attempt to read body out of block' if @socket.nil? || @socket.closed?
   end
 
   def procdest(dest, block)

--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -589,6 +589,41 @@ EOS
     assert_equal 'hello', body
   end
 
+  def test_read_body_receiving_no_body
+    io = dummy_io(<<EOS)
+HTTP/1.1 204 OK
+Connection: close
+
+EOS
+
+    res = Net::HTTPResponse.read_new(io)
+    res.body_encoding = 'utf-8'
+
+    body = 'something to override'
+
+    res.reading_body io, true do
+      body = res.read_body
+    end
+
+    assert_equal nil, body
+    assert_equal nil, res.body
+  end
+
+  def test_read_body_outside_of_reading_body
+    io = dummy_io(<<EOS)
+HTTP/1.1 200 OK
+Connection: close
+Content-Length: 0
+
+EOS
+
+    res = Net::HTTPResponse.read_new(io)
+
+    assert_raise IOError do
+      res.read_body
+    end
+  end
+
   def test_uri_equals
     uri = URI 'http://example'
 


### PR DESCRIPTION
Fix nil handling in read_body and stream_check.

Fixes: #70