### PR TITLE
Revert "Replace Timeout.timeout in Net:HTTP#connect"

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1013,13 +1013,14 @@ module Net   #:nodoc:
       end
 
       debug "opening connection to #{conn_addr}:#{conn_port}..."
-      begin
-        s = Socket.tcp conn_addr, conn_port, @local_host, @local_port, connect_timeout: @open_timeout
-      rescue => e
-        e = Net::OpenTimeout.new(e) if e.is_a?(Errno::ETIMEDOUT) #for compatibility with previous versions
-        raise e, "Failed to open TCP connection to " +
-          "#{conn_addr}:#{conn_port} (#{e.message})"
-      end
+      s = Timeout.timeout(@open_timeout, Net::OpenTimeout) {
+        begin
+          TCPSocket.open(conn_addr, conn_port, @local_host, @local_port)
+        rescue => e
+          raise e, "Failed to open TCP connection to " +
+            "#{conn_addr}:#{conn_port} (#{e.message})"
+        end
+      }
       s.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
       debug "opened"
       if use_ssl?


### PR DESCRIPTION
This reverts commit 753cae3bbccc6325c4acb88b79f0229624ad28d5.

----

We should handle `connect_timeout` and `resolv_timeout` with `Socket.tcp`. But...

  * `Scocket.tcp` does NOT support `resolv_timeout` yet. Because `getaddrinfo_a` support of `Socket` has been reverted.
  * The current implementation of `Socket.tcp` is abandoned by above revert related `getaddrinfo_a`. I'm not sure `connect_timeout` works correctly.