### PR TITLE
Fix test for Ruby head

### DIFF
--- a/test/net/http/test_httpheader.rb
+++ b/test/net/http/test_httpheader.rb
@@ -28,7 +28,11 @@ class HTTPHeaderTest < Test::Unit::TestCase
     assert_raise(NoMethodError){ @c.initialize_http_header("foo"=>[]) }
     assert_raise(ArgumentError){ @c.initialize_http_header("foo"=>"a\nb") }
     assert_raise(ArgumentError){ @c.initialize_http_header("foo"=>"a\rb") }
-    assert_raise(ArgumentError){ @c.initialize_http_header("foo"=>"a\xff") }
+  end
+
+  def test_initialize_with_broken_coderange
+    error = RUBY_VERSION >= "3.2" ? Encoding::CompatibilityError : ArgumentError
+    assert_raise(error){ @c.initialize_http_header("foo"=>"a\xff") }
   end
 
   def test_initialize_with_symbol


### PR DESCRIPTION
The error raised for broken coderanges was changed in ruby/ruby@571d21f and the test was fixed in that commit but not ported to this repo.