### PR TITLE
[DOC] Enhanced RDoc for Net::HTTP

### DIFF
--- a/lib/net/http/request.rb
+++ b/lib/net/http/request.rb
@@ -4,23 +4,28 @@
 # it wraps together the request path and the request headers.
 #
 # The class should not be used directly;
-# instead you should use its subclasses:
+# instead you should use its subclasses.
 #
-# - \Net::HTTP::Get
-# - \Net::HTTP::Head
-# - \Net::HTTP::Post
-# - \Net::HTTP::Delete
-# - \Net::HTTP::Options
-# - \Net::HTTP::Trace
-# - \Net::HTTP::Patch
-# - \Net::HTTP::Put
-# - \Net::HTTP::Copy
-# - \Net::HTTP::Lock
-# - \Net::HTTP::Mkcol
-# - \Net::HTTP::Move
-# - \Net::HTTP::Propfind
-# - \Net::HTTP::Proppatch
-# - \Net::HTTP::Unlock
+# Subclasses for HTTP requests:
+#
+# - Net::HTTP::Get
+# - Net::HTTP::Head
+# - Net::HTTP::Post
+# - Net::HTTP::Put
+# - Net::HTTP::Delete
+# - Net::HTTP::Options
+# - Net::HTTP::Trace
+# - Net::HTTP::Patch
+#
+# Subclasses for WebDAV requests:
+#
+# - Net::HTTP::Propfind
+# - Net::HTTP::Proppatch
+# - Net::HTTP::Mkcol
+# - Net::HTTP::Copy
+# - Net::HTTP::Move
+# - Net::HTTP::Lock
+# - Net::HTTP::Unlock
 #
 class Net::HTTPRequest < Net::HTTPGenericRequest
   # Creates an HTTP request object for +path+.
@@ -36,4 +41,3 @@ class Net::HTTPRequest < Net::HTTPGenericRequest
           path, initheader
   end
 end
-

--- a/lib/net/http/requests.rb
+++ b/lib/net/http/requests.rb
@@ -6,18 +6,9 @@
 # {HTTP method GET}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#GET_method]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Get.new(uri) # => #<Net::HTTP::Get GET>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
-#
 #   res = Net::HTTP.start(hostname) do |http|
 #     http.request(req)
 #   end
@@ -45,18 +36,9 @@ end
 # {HTTP method HEAD}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#HEAD_method]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Head.new(uri) # => #<Net::HTTP::Head HEAD>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
-#
 #   res = Net::HTTP.start(hostname) do |http|
 #     http.request(req)
 #   end
@@ -84,19 +66,10 @@ end
 # {HTTP method POST}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#POST_method]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   uri.path = '/posts'
 #   req = Net::HTTP::Post.new(uri) # => #<Net::HTTP::Post POST>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
-#
 #   req.body = '{"title": "foo","body": "bar","userId": 1}'
 #   req.content_type = 'application/json'
 #   res = Net::HTTP.start(hostname) do |http|
@@ -126,19 +99,10 @@ end
 # {HTTP method PUT}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#PUT_method]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   uri.path = '/posts'
 #   req = Net::HTTP::Put.new(uri) # => #<Net::HTTP::Put PUT>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
-#
 #   req.body = '{"title": "foo","body": "bar","userId": 1}'
 #   req.content_type = 'application/json'
 #   res = Net::HTTP.start(hostname) do |http|
@@ -163,19 +127,10 @@ end
 # {HTTP method DELETE}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#DELETE_method]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   uri.path = '/posts/1'
 #   req = Net::HTTP::Delete.new(uri) # => #<Net::HTTP::Delete DELETE>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
-#
 #   res = Net::HTTP.start(hostname) do |http|
 #     http.request(req)
 #   end
@@ -203,18 +158,9 @@ end
 # {HTTP method OPTIONS}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#OPTIONS_method]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Options.new(uri) # => #<Net::HTTP::Options OPTIONS>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
-#
 #   res = Net::HTTP.start(hostname) do |http|
 #     http.request(req)
 #   end
@@ -242,18 +188,9 @@ end
 # {HTTP method TRACE}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#TRACE_method]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Trace.new(uri) # => #<Net::HTTP::Trace TRACE>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
-#
 #   res = Net::HTTP.start(hostname) do |http|
 #     http.request(req)
 #   end
@@ -281,19 +218,10 @@ end
 # {HTTP method PATCH}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#PATCH_method]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   uri.path = '/posts'
 #   req = Net::HTTP::Patch.new(uri) # => #<Net::HTTP::Patch PATCH>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
-#
 #   req.body = '{"title": "foo","body": "bar","userId": 1}'
 #   req.content_type = 'application/json'
 #   res = Net::HTTP.start(hostname) do |http|
@@ -327,16 +255,12 @@ end
 # {WebDAV method PROPFIND}[http://www.webdav.org/specs/rfc4918.html#METHOD_PROPFIND]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Propfind.new(uri) # => #<Net::HTTP::Propfind PROPFIND>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
 #
 # Related:
 #
@@ -352,16 +276,12 @@ end
 # {WebDAV method PROPPATCH}[http://www.webdav.org/specs/rfc4918.html#METHOD_PROPPATCH]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Proppatch.new(uri) # => #<Net::HTTP::Proppatch PROPPATCH>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
 #
 # Related:
 #
@@ -377,16 +297,12 @@ end
 # {WebDAV method MKCOL}[http://www.webdav.org/specs/rfc4918.html#METHOD_MKCOL]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Mkcol.new(uri) # => #<Net::HTTP::Mkcol MKCOL>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
 #
 # Related:
 #
@@ -402,16 +318,12 @@ end
 # {WebDAV method COPY}[http://www.webdav.org/specs/rfc4918.html#METHOD_COPY]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Copy.new(uri) # => #<Net::HTTP::Copy COPY>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
 #
 # Related:
 #
@@ -427,16 +339,12 @@ end
 # {WebDAV method MOVE}[http://www.webdav.org/specs/rfc4918.html#METHOD_MOVE]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Move.new(uri) # => #<Net::HTTP::Move MOVE>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
 #
 # Related:
 #
@@ -452,16 +360,12 @@ end
 # {WebDAV method LOCK}[http://www.webdav.org/specs/rfc4918.html#METHOD_LOCK]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Lock.new(uri) # => #<Net::HTTP::Lock LOCK>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
 #
 # Related:
 #
@@ -477,16 +381,12 @@ end
 # {WebDAV method UNLOCK}[http://www.webdav.org/specs/rfc4918.html#METHOD_UNLOCK]:
 #
 #   require 'net/http'
-#   uri = URI('https://jsonplaceholder.typicode.com')
-#
+#   uri = URI('http://example.com')
+#   hostname = uri.hostname # => "example.com"
 #   req = Net::HTTP::Unlock.new(uri) # => #<Net::HTTP::Unlock UNLOCK>
-#   # Default headers.
-#   req.to_hash
-#   # =>
-#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
-#    "accept"=>["*/*"],
-#    "user-agent"=>["Ruby"],
-#    "host"=>["jsonplaceholder.typicode.com"]}
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
 #
 # Related:
 #

--- a/lib/net/http/requests.rb
+++ b/lib/net/http/requests.rb
@@ -53,7 +53,6 @@ end
 #
 # Related:
 #
-# - Net::HTTP.head: sends +HEAD+ request, returns response object.
 # - Net::HTTP#head: sends +HEAD+ request, returns response object.
 #
 class Net::HTTP::Head < Net::HTTPRequest
@@ -145,7 +144,6 @@ end
 #
 # Related:
 #
-# - Net::HTTP.delete: sends +DELETE+ request, returns response object.
 # - Net::HTTP#delete: sends +DELETE+ request, returns response object.
 #
 class Net::HTTP::Delete < Net::HTTPRequest
@@ -175,7 +173,6 @@ end
 #
 # Related:
 #
-# - Net::HTTP.options: sends +OPTIONS+ request, returns response object.
 # - Net::HTTP#options: sends +OPTIONS+ request, returns response object.
 #
 class Net::HTTP::Options < Net::HTTPRequest
@@ -205,7 +202,6 @@ end
 #
 # Related:
 #
-# - Net::HTTP.trace: sends +TRACE+ request, returns response object.
 # - Net::HTTP#trace: sends +TRACE+ request, returns response object.
 #
 class Net::HTTP::Trace < Net::HTTPRequest
@@ -238,7 +234,6 @@ end
 #
 # Related:
 #
-# - Net::HTTP.patch: sends +PATCH+ request, returns response object.
 # - Net::HTTP#patch: sends +PATCH+ request, returns response object.
 #
 class Net::HTTP::Patch < Net::HTTPRequest

--- a/lib/net/http/requests.rb
+++ b/lib/net/http/requests.rb
@@ -1,67 +1,318 @@
 # frozen_string_literal: false
-#
-# HTTP/1.1 methods --- RFC2616
-#
 
-# See Net::HTTPGenericRequest for attributes and methods.
-# See Net::HTTP for usage examples.
+# HTTP/1.1 methods --- RFC2616
+
+# \Class for representing
+# {HTTP method GET}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#GET_method]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
+#
+#   req = Net::HTTP::Get.new(uri) # => #<Net::HTTP::Get GET>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# Properties:
+#
+# - Request body: optional.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: yes.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: yes.
+#
+# Related:
+#
+# - Net::HTTP.get: sends +GET+ request, returns response body.
+# - Net::HTTP#get: sends +GET+ request, returns response object.
+#
 class Net::HTTP::Get < Net::HTTPRequest
   METHOD = 'GET'
   REQUEST_HAS_BODY  = false
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
-# See Net::HTTP for usage examples.
+# \Class for representing
+# {HTTP method HEAD}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#HEAD_method]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
+#
+#   req = Net::HTTP::Head.new(uri) # => #<Net::HTTP::Head HEAD>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# Properties:
+#
+# - Request body: optional.
+# - Response body: no.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: yes.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: yes.
+#
+# Related:
+#
+# - Net::HTTP.head: sends +HEAD+ request, returns response object.
+# - Net::HTTP#head: sends +HEAD+ request, returns response object.
+#
 class Net::HTTP::Head < Net::HTTPRequest
   METHOD = 'HEAD'
   REQUEST_HAS_BODY = false
   RESPONSE_HAS_BODY = false
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
-# See Net::HTTP for usage examples.
+# \Class for representing
+# {HTTP method POST}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#POST_method]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
+#
+#   uri.path = '/posts'
+#   req = Net::HTTP::Post.new(uri) # => #<Net::HTTP::Post POST>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+#   req.body = '{"title": "foo","body": "bar","userId": 1}'
+#   req.content_type = 'application/json'
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# Properties:
+#
+# - Request body: yes.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: no.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: no.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: yes.
+#
+# Related:
+#
+# - Net::HTTP.post: sends +POST+ request, returns response object.
+# - Net::HTTP#post: sends +POST+ request, returns response object.
+#
 class Net::HTTP::Post < Net::HTTPRequest
   METHOD = 'POST'
   REQUEST_HAS_BODY = true
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
-# See Net::HTTP for usage examples.
+# \Class for representing
+# {HTTP method PUT}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#PUT_method]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
+#
+#   uri.path = '/posts'
+#   req = Net::HTTP::Put.new(uri) # => #<Net::HTTP::Put PUT>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+#   req.body = '{"title": "foo","body": "bar","userId": 1}'
+#   req.content_type = 'application/json'
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# Properties:
+#
+# - Request body: yes.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: no.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
 class Net::HTTP::Put < Net::HTTPRequest
   METHOD = 'PUT'
   REQUEST_HAS_BODY = true
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
-# See Net::HTTP for usage examples.
+# \Class for representing
+# {HTTP method DELETE}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#DELETE_method]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
+#
+#   uri.path = '/posts/1'
+#   req = Net::HTTP::Delete.new(uri) # => #<Net::HTTP::Delete DELETE>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# Properties:
+#
+# - Request body: optional.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: no.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
+# Related:
+#
+# - Net::HTTP.delete: sends +DELETE+ request, returns response object.
+# - Net::HTTP#delete: sends +DELETE+ request, returns response object.
+#
 class Net::HTTP::Delete < Net::HTTPRequest
   METHOD = 'DELETE'
   REQUEST_HAS_BODY = false
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
+# \Class for representing
+# {HTTP method OPTIONS}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#OPTIONS_method]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
+#
+#   req = Net::HTTP::Options.new(uri) # => #<Net::HTTP::Options OPTIONS>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# Properties:
+#
+# - Request body: optional.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: yes.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
+# Related:
+#
+# - Net::HTTP.options: sends +OPTIONS+ request, returns response object.
+# - Net::HTTP#options: sends +OPTIONS+ request, returns response object.
+#
 class Net::HTTP::Options < Net::HTTPRequest
   METHOD = 'OPTIONS'
   REQUEST_HAS_BODY = false
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
+# \Class for representing
+# {HTTP method TRACE}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#TRACE_method]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
+#
+#   req = Net::HTTP::Trace.new(uri) # => #<Net::HTTP::Trace TRACE>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# Properties:
+#
+# - Request body: no.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: yes.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: yes.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
+# Related:
+#
+# - Net::HTTP.trace: sends +TRACE+ request, returns response object.
+# - Net::HTTP#trace: sends +TRACE+ request, returns response object.
+#
 class Net::HTTP::Trace < Net::HTTPRequest
   METHOD = 'TRACE'
   REQUEST_HAS_BODY = false
   RESPONSE_HAS_BODY = true
 end
 
+# \Class for representing
+# {HTTP method PATCH}[https://en.wikipedia.org/w/index.php?title=Hypertext_Transfer_Protocol#PATCH_method]:
 #
-# PATCH method --- RFC5789
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#   hostname = uri.hostname # => "jsonplaceholder.typicode.com"
 #
-
-# See Net::HTTPGenericRequest for attributes and methods.
+#   uri.path = '/posts'
+#   req = Net::HTTP::Patch.new(uri) # => #<Net::HTTP::Patch PATCH>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+#   req.body = '{"title": "foo","body": "bar","userId": 1}'
+#   req.content_type = 'application/json'
+#   res = Net::HTTP.start(hostname) do |http|
+#     http.request(req)
+#   end
+#
+# Properties:
+#
+# - Request body: yes.
+# - Response body: yes.
+# - {Safe}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Safe_methods]: no.
+# - {Idempotent}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Idempotent_methods]: no.
+# - {Cacheable}[https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Cacheable_methods]: no.
+#
+# Related:
+#
+# - Net::HTTP.patch: sends +PATCH+ request, returns response object.
+# - Net::HTTP#patch: sends +PATCH+ request, returns response object.
+#
 class Net::HTTP::Patch < Net::HTTPRequest
   METHOD = 'PATCH'
   REQUEST_HAS_BODY = true
@@ -72,49 +323,175 @@ end
 # WebDAV methods --- RFC2518
 #
 
-# See Net::HTTPGenericRequest for attributes and methods.
+# \Class for representing
+# {WebDAV method PROPFIND}[http://www.webdav.org/specs/rfc4918.html#METHOD_PROPFIND]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#
+#   req = Net::HTTP::Propfind.new(uri) # => #<Net::HTTP::Propfind PROPFIND>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+# Related:
+#
+# - Net::HTTP#propfind: sends +PROPFIND+ request, returns response object.
+#
 class Net::HTTP::Propfind < Net::HTTPRequest
   METHOD = 'PROPFIND'
   REQUEST_HAS_BODY = true
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
+# \Class for representing
+# {WebDAV method PROPPATCH}[http://www.webdav.org/specs/rfc4918.html#METHOD_PROPPATCH]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#
+#   req = Net::HTTP::Proppatch.new(uri) # => #<Net::HTTP::Proppatch PROPPATCH>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+# Related:
+#
+# - Net::HTTP#proppatch: sends +PROPPATCH+ request, returns response object.
+#
 class Net::HTTP::Proppatch < Net::HTTPRequest
   METHOD = 'PROPPATCH'
   REQUEST_HAS_BODY = true
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
+# \Class for representing
+# {WebDAV method MKCOL}[http://www.webdav.org/specs/rfc4918.html#METHOD_MKCOL]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#
+#   req = Net::HTTP::Mkcol.new(uri) # => #<Net::HTTP::Mkcol MKCOL>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+# Related:
+#
+# - Net::HTTP#mkcol: sends +MKCOL+ request, returns response object.
+#
 class Net::HTTP::Mkcol < Net::HTTPRequest
   METHOD = 'MKCOL'
   REQUEST_HAS_BODY = true
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
+# \Class for representing
+# {WebDAV method COPY}[http://www.webdav.org/specs/rfc4918.html#METHOD_COPY]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#
+#   req = Net::HTTP::Copy.new(uri) # => #<Net::HTTP::Copy COPY>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+# Related:
+#
+# - Net::HTTP#copy: sends +COPY+ request, returns response object.
+#
 class Net::HTTP::Copy < Net::HTTPRequest
   METHOD = 'COPY'
   REQUEST_HAS_BODY = false
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
+# \Class for representing
+# {WebDAV method MOVE}[http://www.webdav.org/specs/rfc4918.html#METHOD_MOVE]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#
+#   req = Net::HTTP::Move.new(uri) # => #<Net::HTTP::Move MOVE>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+# Related:
+#
+# - Net::HTTP#move: sends +MOVE+ request, returns response object.
+#
 class Net::HTTP::Move < Net::HTTPRequest
   METHOD = 'MOVE'
   REQUEST_HAS_BODY = false
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
+# \Class for representing
+# {WebDAV method LOCK}[http://www.webdav.org/specs/rfc4918.html#METHOD_LOCK]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#
+#   req = Net::HTTP::Lock.new(uri) # => #<Net::HTTP::Lock LOCK>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+# Related:
+#
+# - Net::HTTP#lock: sends +LOCK+ request, returns response object.
+#
 class Net::HTTP::Lock < Net::HTTPRequest
   METHOD = 'LOCK'
   REQUEST_HAS_BODY = true
   RESPONSE_HAS_BODY = true
 end
 
-# See Net::HTTPGenericRequest for attributes and methods.
+# \Class for representing
+# {WebDAV method UNLOCK}[http://www.webdav.org/specs/rfc4918.html#METHOD_UNLOCK]:
+#
+#   require 'net/http'
+#   uri = URI('https://jsonplaceholder.typicode.com')
+#
+#   req = Net::HTTP::Unlock.new(uri) # => #<Net::HTTP::Unlock UNLOCK>
+#   # Default headers.
+#   req.to_hash
+#   # =>
+#   {"accept-encoding"=>["gzip;q=1.0,deflate;q=0.6,identity;q=0.3"],
+#    "accept"=>["*/*"],
+#    "user-agent"=>["Ruby"],
+#    "host"=>["jsonplaceholder.typicode.com"]}
+#
+# Related:
+#
+# - Net::HTTP#unlock: sends +UNLOCK+ request, returns response object.
+#
 class Net::HTTP::Unlock < Net::HTTPRequest
   METHOD = 'UNLOCK'
   REQUEST_HAS_BODY = true


### PR DESCRIPTION
Adds documentation for classes `Net::HTTP::`_verb_ for 15 verbs (HTTP and WebDAV).  Adds links to those pages from `Net::HTTPRequest`.

Reviewers, you can verify the given properties at https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Properties_of_request_methods_table.