### PR TITLE
don't invoke response block more than once due to retry

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1634,7 +1634,10 @@ module Net   #:nodoc:
           res
         }
         res.reading_body(@socket, req.response_body_permitted?) {
-          yield res if block_given?
+          if block_given?
+            count = max_retries # Don't restart in the middle of a download
+            yield res
+          end
         }
       rescue Net::OpenTimeout
         raise


### PR DESCRIPTION
If a socket error occurs while performing a streaming download via the response block provided to transport_request, avoid calling the response block again as this would result in duplicate data received by the client.

fixes #86