### PR TITLE
Initial approach to allowing SSL context option passing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.tool-versions
+/Gemfile.lock

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -658,6 +658,7 @@ module Net   #:nodoc:
     # - #open_timeout
     # - #read_timeout
     # - #ssl_timeout
+    # - #ssl_options
     # - #ssl_version
     # - +use_ssl+ (calls #use_ssl=)
     # - #verify_callback
@@ -1132,6 +1133,7 @@ module Net   #:nodoc:
       :@extra_chain_cert,
       :@key,
       :@ssl_timeout,
+      :@ssl_options,
       :@ssl_version,
       :@min_version,
       :@max_version,
@@ -1149,6 +1151,7 @@ module Net   #:nodoc:
       :extra_chain_cert,
       :key,
       :ssl_timeout,
+      :options,
       :ssl_version,
       :min_version,
       :max_version,
@@ -1187,6 +1190,9 @@ module Net   #:nodoc:
 
     # Sets the SSL timeout seconds.
     attr_accessor :ssl_timeout
+
+    # Sets the SSL options. See OpenSSL::SSL::SSLContext#ssl_options=
+    attr_accessor :ssl_options
 
     # Sets the SSL version.  See OpenSSL::SSL::SSLContext#ssl_version=
     attr_accessor :ssl_version

--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -307,4 +307,14 @@ class TestNetHTTPS < Test::Unit::TestCase
     assert_match(re_msg, ex.message)
   end
 
+  def test_ssl_options
+    http = Net::HTTP.new(HOST, config("port"))
+    http.use_ssl = true
+    http.ssl_options = OpenSSL::SSL::OP_LEGACY_SERVER_CONNECT
+    http.cert_store = TEST_STORE
+    http.request_get("/") {|res|
+      assert_equal($test_net_http_data, res.body)
+    }
+  end
+
 end if defined?(OpenSSL::SSL)


### PR DESCRIPTION
Hello!

This is really meant more to start a conversation since there's likely a lot of implications to this change I'm not aware of.

I've found that it would be very convenient to be able to pass in `options` to the underlying SSL Context, this provides support for flags like `OP_LEGACY_SERVER_CONNECT` and `OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION`. Which while dangerous do provide real utility. This was proposed in the [past](https://bugs.ruby-lang.org/issues/9450) however at the time it was for passing in the flags that block specific SSL versions. This proposal was closed when min/max version parameters were added. I think the underlying need is still there so I'm opening this up to get some feedback.