### PR TITLE
fix character encoding sniffing

### DIFF
--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -519,19 +519,16 @@ class Net::HTTPResponse
     case ss.peek(1)
     when '"'
       ss.getch
-      value = ss.scan(/[^"]+/)
-      value.downcase!
+      value = ss.scan(/[^"]+/)&.downcase
       ss.getch
     when "'"
       ss.getch
-      value = ss.scan(/[^']+/)
-      value.downcase!
+      value = ss.scan(/[^']+/)&.downcase
       ss.getch
     when '>'
       value = ''
     else
-      value = ss.scan(/[^\t\n\f\r >]+/)
-      value.downcase!
+      value = ss.scan(/[^\t\n\f\r >]+/)&.downcase
     end
     [name, value]
   end

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -463,7 +463,7 @@ class Net::HTTPResponse
   def scanning_meta(str)
     require 'strscan'
     ss = StringScanner.new(str)
-    if ss.scan_until(/<meta[\t\n\f\r ]*/)
+    while ss.scan_until(/<meta[\t\n\f\r ]*/)
       attrs = {} # attribute_list
       got_pragma = false
       need_pragma = nil
@@ -490,11 +490,11 @@ class Net::HTTPResponse
       end
 
       # step: Processing
-      return if need_pragma.nil?
-      return if need_pragma && !got_pragma
+      next if need_pragma.nil?
+      next if need_pragma && !got_pragma
 
       charset = Encoding.find(charset) rescue nil
-      return unless charset
+      next unless charset
       charset = Encoding::UTF_8 if charset == Encoding::UTF_16
       return charset # tentative
     end

--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -265,6 +265,30 @@ EOS
     assert_equal Encoding::UTF_8, body.encoding
   end
 
+  def test_read_body_body_encoding_true_with_empty_meta_content
+    res_body = "<meta name='keywords' content=''>hello\u1234</html>"
+    io = dummy_io(<<EOS)
+HTTP/1.1 200 OK
+Connection: close
+Content-Length: #{res_body.bytesize}
+Content-Type: text/html
+
+#{res_body}
+EOS
+
+    res = Net::HTTPResponse.read_new(io)
+    res.body_encoding = true
+
+    body = nil
+
+    res.reading_body io, true do
+      body = res.read_body
+    end
+
+    assert_equal res_body, body
+    assert_equal Encoding::UTF_8, body.encoding
+  end
+
   def test_read_body_body_encoding_true_with_iso8859_1_meta_content_charset
     res_body = "<meta http-equiv='content-type' content='text/html; charset=ISO-8859-1'>hello\u1234</html>"
     io = dummy_io(<<EOS)

--- a/test/net/http/test_httpresponse.rb
+++ b/test/net/http/test_httpresponse.rb
@@ -242,7 +242,7 @@ EOS
   end
 
   def test_read_body_body_encoding_true_with_utf8_meta_content_charset
-    res_body = "<meta http-equiv='content-type' content='text/html; charset=UTF-8'>hello\u1234</html>"
+    res_body = "<meta http-equiv='content-type' content='text/html; charset=UTF-8'>hello</html>"
     io = dummy_io(<<EOS)
 HTTP/1.1 200 OK
 Connection: close
@@ -266,7 +266,7 @@ EOS
   end
 
   def test_read_body_body_encoding_true_with_empty_meta_content
-    res_body = "<meta name='keywords' content=''>hello\u1234</html>"
+    res_body = "<meta name='keywords' content=''><meta http-equiv='content-type' content='text/html; charset=UTF-8'>"
     io = dummy_io(<<EOS)
 HTTP/1.1 200 OK
 Connection: close


### PR DESCRIPTION
This fixes two bugs I found when `force_response_body_encoding` (#17) is enabled.

1. `scanning_meta` only checks the first `meta` element
2. an attribute with no content (for example, `<meta name='keywords' content=''>`) breaks `get_attribute`

The `scanning_meta` change makes the code more similar to the original sniffing patch in https://bugs.ruby-lang.org/issues/2567. There may be an issue with the `while` and large content bodies. Maybe it should stop at `<body>` as well?