### PR TITLE
Use frozen string literals

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1615,8 +1615,8 @@ module Net   #:nodoc:
                                       write_timeout: @write_timeout,
                                       continue_timeout: @continue_timeout,
                                       debug_output: @debug_output)
-          buf = +"CONNECT #{conn_address}:#{@port} HTTP/#{HTTPVersion}\r\n"
-          buf << "Host: #{@address}:#{@port}\r\n"
+          buf = +"CONNECT #{conn_address}:#{@port} HTTP/#{HTTPVersion}\r\n" \
+            "Host: #{@address}:#{@port}\r\n"
           if proxy_user
             credential = ["#{proxy_user}:#{proxy_pass}"].pack('m0')
             buf << "Proxy-Authorization: Basic #{credential}\r\n"

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1615,7 +1615,7 @@ module Net   #:nodoc:
                                       write_timeout: @write_timeout,
                                       continue_timeout: @continue_timeout,
                                       debug_output: @debug_output)
-          buf = "CONNECT #{conn_address}:#{@port} HTTP/#{HTTPVersion}\r\n"
+          buf = +"CONNECT #{conn_address}:#{@port} HTTP/#{HTTPVersion}\r\n"
           buf << "Host: #{@address}:#{@port}\r\n"
           if proxy_user
             credential = ["#{proxy_user}:#{proxy_pass}"].pack('m0')

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # = net/http.rb
 #

--- a/lib/net/http/backward.rb
+++ b/lib/net/http/backward.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 # for backward compatibility
 
 # :enddoc:

--- a/lib/net/http/exceptions.rb
+++ b/lib/net/http/exceptions.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 module Net
   # Net::HTTP exception class.
   # You cannot use Net::HTTPExceptions directly; instead, you must use

--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -316,7 +316,7 @@ class Net::HTTPGenericRequest
     boundary ||= SecureRandom.urlsafe_base64(40)
     chunked_p = chunked?
 
-    buf = String.new
+    buf = +''
     params.each do |key, value, h={}|
       key = quote_string(key, charset)
       filename =
@@ -401,7 +401,7 @@ class Net::HTTPGenericRequest
     if /[\r\n]/ =~ reqline
       raise ArgumentError, "A Request-Line must not contain CR or LF"
     end
-    buf = String.new
+    buf = +''
     buf << reqline << "\r\n"
     each_capitalized do |k,v|
       buf << "#{k}: #{v}\r\n"

--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # \HTTPGenericRequest is the parent of the Net::HTTPRequest class.
 #
@@ -316,7 +316,7 @@ class Net::HTTPGenericRequest
     boundary ||= SecureRandom.urlsafe_base64(40)
     chunked_p = chunked?
 
-    buf = ''
+    buf = String.new
     params.each do |key, value, h={}|
       key = quote_string(key, charset)
       filename =
@@ -401,7 +401,7 @@ class Net::HTTPGenericRequest
     if /[\r\n]/ =~ reqline
       raise ArgumentError, "A Request-Line must not contain CR or LF"
     end
-    buf = ""
+    buf = String.new
     buf << reqline << "\r\n"
     each_capitalized do |k,v|
       buf << "#{k}: #{v}\r\n"

--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 #
 # The \HTTPHeader module provides access to \HTTP headers.
 #

--- a/lib/net/http/proxy_delta.rb
+++ b/lib/net/http/proxy_delta.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 module Net::HTTP::ProxyDelta   #:nodoc: internal use only
   private
 

--- a/lib/net/http/request.rb
+++ b/lib/net/http/request.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 # This class is the base class for \Net::HTTP request classes.
 # The class should not be used directly;

--- a/lib/net/http/requests.rb
+++ b/lib/net/http/requests.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 # HTTP/1.1 methods --- RFC2616
 

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 # This class is the base class for \Net::HTTP response classes.
 #
@@ -273,7 +273,7 @@ class Net::HTTPResponse
 
   def error!   #:nodoc:
     message = @code
-    message += ' ' + @message.dump if @message
+    message += " #{@message.dump}" if @message
     raise error_type().new(message, self)
   end
 
@@ -648,7 +648,7 @@ class Net::HTTPResponse
     if block
       Net::ReadAdapter.new(block)
     else
-      dest || ''
+      dest || String.new
     end
   end
 

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -648,7 +648,7 @@ class Net::HTTPResponse
     if block
       Net::ReadAdapter.new(block)
     else
-      dest || String.new
+      dest || +''
     end
   end
 

--- a/lib/net/http/response.rb
+++ b/lib/net/http/response.rb
@@ -273,7 +273,7 @@ class Net::HTTPResponse
 
   def error!   #:nodoc:
     message = @code
-    message += " #{@message.dump}" if @message
+    message = "#{message} #{@message.dump}" if @message
     raise error_type().new(message, self)
   end
 

--- a/lib/net/https.rb
+++ b/lib/net/https.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 =begin
 
 = net/https -- SSL/TLS enhancement for Net::HTTP.


### PR DESCRIPTION
I've been using [memory_profiler](https://github.com/SamSaffron/memory_profiler) on an extremely slow Rails system spec, and was surprised to see net/http came up in it. This particular test does an absolute _ton_ of HTTP requests though.

I was looking through this code, and realized there's a lot of string literals used in some of the hot code paths, but `frozen_string_literal` had been explicitly set to false. There was only a few small changes after turning frozen_string_literal on to get the suite passing.

I tested my app against this, and it shaved off some 23s, from 2m15s to 1m52s 😱

I'll post before/after of the memory_profiler reports shortly.