### PR TITLE
Improve performance of HTTPHeader#content_type

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -699,10 +699,14 @@ module Net::HTTPHeader
   #   res.content_type    # => "application/json"
   #
   def content_type
-    return nil unless main_type()
-    if sub_type()
-    then "#{main_type()}/#{sub_type()}"
-    else main_type()
+    main = main_type()
+    return nil unless main
+
+    sub = sub_type()
+    if sub
+      "#{main}/#{sub}"
+    else
+      main
     end
   end
 


### PR DESCRIPTION
In the existing implementation, `main_type` and `sub_type` would end up being called multiple times potentially.

Instead of doing that, save the result so it can be re-used.