### PR TITLE
No longer neccessary to call `String#freeze` on string literals.

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1798,7 +1798,7 @@ module Net   #:nodoc:
     def proxy_uri # :nodoc:
       return if @proxy_uri == false
       @proxy_uri ||= URI::HTTP.new(
-        "http".freeze, nil, address, port, nil, nil, nil, nil, nil
+        "http", nil, address, port, nil, nil, nil, nil, nil
       ).find_proxy || false
       @proxy_uri || nil
     end

--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -23,7 +23,7 @@ class Net::HTTPGenericRequest
       raise ArgumentError, "no host component for URI" unless (hostname && hostname.length > 0)
       @uri = uri_or_path.dup
       host = @uri.hostname.dup
-      host << ":".freeze << @uri.port.to_s if @uri.port != @uri.default_port
+      host << ":" << @uri.port.to_s if @uri.port != @uri.default_port
       @path = uri_or_path.request_uri
       raise ArgumentError, "no HTTP request path given" unless @path
     else
@@ -212,15 +212,15 @@ class Net::HTTPGenericRequest
     return unless @uri
 
     if ssl
-      scheme = 'https'.freeze
+      scheme = 'https'
       klass = URI::HTTPS
     else
-      scheme = 'http'.freeze
+      scheme = 'http'
       klass = URI::HTTP
     end
 
     if host = self['host']
-      host.sub!(/:.*/m, ''.freeze)
+      host.sub!(/:.*/m, '')
     elsif host = @uri.host
     else
      host = addr


### PR DESCRIPTION
See #144