### PR TITLE
Add support for URI that contains an IPv6 address

### DIFF
--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -19,10 +19,10 @@ class Net::HTTPGenericRequest
 
     if URI === uri_or_path then
       raise ArgumentError, "not an HTTP URI" unless URI::HTTP === uri_or_path
-      hostname = uri_or_path.hostname
-      raise ArgumentError, "no host component for URI" unless (hostname && hostname.length > 0)
+      host = uri_or_path.host
+      raise ArgumentError, "no host component for URI" unless (host && host.length > 0)
       @uri = uri_or_path.dup
-      host = @uri.hostname.dup
+      host = host.dup
       host << ":" << @uri.port.to_s if @uri.port != @uri.default_port
       @path = uri_or_path.request_uri
       raise ArgumentError, "no HTTP request path given" unless @path
@@ -220,7 +220,7 @@ class Net::HTTPGenericRequest
     end
 
     if host = self['host']
-      host.sub!(/:.*/m, '')
+      host.sub!(/:\d+\Z/, '')
     elsif host = @uri.host
     else
      host = addr

--- a/test/net/http/test_http_request.rb
+++ b/test/net/http/test_http_request.rb
@@ -89,5 +89,27 @@ class HTTPRequestTest < Test::Unit::TestCase
                          'Bug #7831 - do not decode content if the user overrides'
   end if Net::HTTP::HAVE_ZLIB
 
+  def test_ipv6_address_as_host_header
+    req = Net::HTTP::Get.new(URI.parse("http://[::1]"))
+    assert_equal "[::1]", req["host"]
+  end
+
+  def test_ipv6_address_as_host_header_with_port
+    req = Net::HTTP::Get.new(URI.parse("http://[::1]:2020"))
+    assert_equal "[::1]:2020", req["host"]
+  end
+
+  def test_ipv6_address_on_update_uri
+    req = Net::HTTP::Get.new(URI.parse("http://[::1]"))
+    req.send(:update_uri, "[::1]", 80, false)
+    assert_equal  "[::1]", req.instance_variable_get(:@uri).host
+  end
+
+  def test_ipv6_address_with_port_on_update_uri
+    req = Net::HTTP::Get.new(URI.parse("http://[::1]:7777"))
+    req.send(:update_uri, "[::1]", 2020, false)
+    assert_equal "[::1]", req.instance_variable_get(:@uri).host
+    assert_equal 2020, req.instance_variable_get(:@uri).port
+  end
 end
 


### PR DESCRIPTION
Fix #73:
Net::HTTP.get_response(URI.parse("http://[::1]"))

When the 'Host' header does not wrap an IPv6 address
in brackets, some servers (eg Apache) reject the request
with a 400 status code.