### PR TITLE
Force TLS version to 1.2 when using LibreSSL

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -148,7 +148,7 @@ class TestNetHTTPS < Test::Unit::TestCase
       # support session resuse.  Limiting the version to the TLSv1.2 stack allows
       # this test to continue to work on LibreSSL 3.2+.  LibreSSL may eventually
       # support session reuse, but there are no current plans to do so.
-      http.ssl_version = :TLSv1
+      http.ssl_version = :TLSv1_2
     end
 
     http.start


### PR DESCRIPTION
This comment previously specified TLS 1.2, but actually set the version to TLS 1.0.  LibreSSL 3.8.1 (included in OpenBSD 7.4) dropped support for TLS 1.0/1.1 for security reasons, which broke this test.  Switch the test to use TLS 1.2 as documented so it will continue to work on OpenBSD 7.4+.