### PR TITLE
Actions test.yml - add Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,13 @@ jobs:
     needs: ruby-versions
     name: test (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
+      fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        include:
+          - { os: windows-latest, ruby: mswin }
+          - { os: windows-latest, ruby: ucrt  }
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Adds Windows CI, including mswin build.

This will fail unless #162 is merged, or the test failing in ruby CI is fixed:
```
    1) Failure:
  TestNetHTTPS#test_session_reuse_but_expire [D:/a/ruby/ruby/src/test/net/http/test_https.rb:184]:
  <false> expected but was
  <true>.
```