### PR TITLE
net/http.rb - fixup session timeout logic for OpenSSL 3

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -502,7 +502,7 @@ module Net   #:nodoc:
   # - {:ssl_timeout}[rdoc-ref:Net::HTTP#ssl_timeout]:
   #   Returns the ssl timeout.
   # - {:ssl_timeout=}[rdoc-ref:Net::HTTP#ssl_timeout=]:
-  #   Sets the ssl timeout.
+  #   Sets the client ssl session timeout. A zero or negative value will disable client session reuse.
   # - {:write_timeout}[rdoc-ref:Net::HTTP#write_timeout]:
   #   Returns the write timeout.
   # - {write_timeout=}[rdoc-ref:Net::HTTP#write_timeout=]:

--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1668,7 +1668,9 @@ module Net   #:nodoc:
         s.hostname = ssl_host_address if s.respond_to?(:hostname=) && ssl_host_address
 
         if @ssl_session and
-           Process.clock_gettime(Process::CLOCK_REALTIME) < @ssl_session.time.to_f + @ssl_session.timeout
+          # @ssl_session.timeout is not reliable due to signed/unsigned issues with OpenSSL 3,
+          # use only if s.context.timeout is nil
+          Process.clock_gettime(Process::CLOCK_REALTIME) < @ssl_session.time.to_f + (s.context.timeout || @ssl_session.timeout)
           s.session = @ssl_session
         end
         ssl_socket_connect(s, @open_timeout)


### PR DESCRIPTION
In OpenSSL 3, `session.timeout` may not allow negative values, although `context.timeout` can be negative.  For more info see https://github.com/ruby/openssl/issues/703.

Since the code here is using `session.timeout` in a non-standard way, use `context.timeout`.  If it's nil, use `session.timeout`.  This allows the code to work with OpenSSL 3.2.0.