### PR TITLE
don't invoke response block more than once due to retry

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -2350,7 +2350,10 @@ module Net   #:nodoc:
           res
         }
         res.reading_body(@socket, req.response_body_permitted?) {
-          yield res if block_given?
+          if block_given?
+            count = max_retries # Don't restart in the middle of a download
+            yield res
+          end
         }
       rescue Net::OpenTimeout
         raise

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -1234,6 +1234,16 @@ class TestNetHTTPKeepAlive < Test::Unit::TestCase
     }
   end
 
+  def test_http_retry_failed_with_block
+    start {|http|
+      http.max_retries = 10
+      called = 0
+      assert_raise(Errno::ECONNRESET){ http.get('/'){called += 1; raise Errno::ECONNRESET} }
+      assert_equal 1, called
+    }
+    @log_tester = nil
+  end
+
   def test_keep_alive_server_close
     def @server.run(sock)
       sock.close


### PR DESCRIPTION
This rebases #87 against master and adds a test.