### PR TITLE
test_https.rb - fix test_session_reuse_but_expire

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -167,18 +167,16 @@ class TestNetHTTPS < Test::Unit::TestCase
   def test_session_reuse_but_expire
     # FIXME: The new_session_cb is known broken for clients in OpenSSL 1.1.0h.
     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 1.1.0h')
-    omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.2.')
-    omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.3.')
 
     http = Net::HTTP.new(HOST, config("port"))
     http.use_ssl = true
     http.cert_store = TEST_STORE
 
-    http.ssl_timeout = -1
+    http.ssl_timeout = 1
     http.start
     http.get("/")
     http.finish
-
+    sleep 1.25
     http.start
     http.get("/")
 


### PR DESCRIPTION
See issue https://github.com/ruby/openssl/issues/703

Currently, test code uses `http.ssl_timeout = -1`.  A negative timeout many would consider to be undefined.  As discussed in the ruby/openssl issue, OpenSSL 3.2 changed the timeout value type from signed to unsigned.

So, the previous test was relying on behavior that was undefined.

Changed the timeout value to `1`, and added a `sleep 1.25` command to wait for the second socket connection.

Using a negative value previously performed the equivalent of 'no session reuse'.  A better solution would be to add
a `session_cache_mode` accessor.  I can do that in another PR if there's interest.