### PR TITLE
connection hooks cleanup

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1626,23 +1626,20 @@ module Net   #:nodoc:
     #
     def start  # :yield: http
       raise IOError, 'HTTP session already opened' if @started
+
+      @started = true
+      connect
+
       if block_given?
         begin
-          do_start
           return yield(self)
         ensure
-          do_finish
+          finish
         end
       end
-      do_start
+
       self
     end
-
-    def do_start
-      connect
-      @started = true
-    end
-    private :do_start
 
     def connect
       if use_ssl?
@@ -1750,7 +1747,6 @@ module Net   #:nodoc:
                                continue_timeout: @continue_timeout,
                                debug_output: @debug_output)
       @last_communicated = nil
-      on_connect
     rescue => exception
       if s
         debug "Conn close because of connect error #{exception}"
@@ -1759,10 +1755,6 @@ module Net   #:nodoc:
       raise
     end
     private :connect
-
-    def on_connect
-    end
-    private :on_connect
 
     # Finishes the \HTTP session:
     #
@@ -1775,15 +1767,10 @@ module Net   #:nodoc:
     # Raises IOError if not in a session.
     def finish
       raise IOError, 'HTTP session not yet started' unless started?
-      do_finish
-    end
-
-    def do_finish
       @started = false
       @socket.close if @socket
       @socket = nil
     end
-    private :do_finish
 
     #
     # proxy


### PR DESCRIPTION
I'm curious about net-http's hooks, eg. `do_start`, `on_connect`, and `do_finish`.  They're marked as private and seem largely unused (and untested).  Do we still need/want them?

If we do want them, what is their intended use?  Could we make them public methods so they're available for broader consumption?