### PR TITLE
Freeze some constants to improve Ractor compatibility

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1529,7 +1529,7 @@ module Net   #:nodoc:
       :verify_hostname,
     ] # :nodoc:
 
-    SSL_IVNAMES = SSL_ATTRIBUTES.map { |a| "@#{a}".to_sym } # :nodoc:
+    SSL_IVNAMES = SSL_ATTRIBUTES.map { |a| "@#{a}".to_sym }.freeze # :nodoc:
 
     # Sets or returns the path to a CA certification file in PEM format.
     attr_accessor :ca_file

--- a/lib/net/http/responses.rb
+++ b/lib/net/http/responses.rb
@@ -1104,7 +1104,7 @@ class Net::HTTPResponse
     '3' => Net::HTTPRedirection,
     '4' => Net::HTTPClientError,
     '5' => Net::HTTPServerError
-  }
+  }.freeze
   CODE_TO_OBJ = {
     '100' => Net::HTTPContinue,
     '101' => Net::HTTPSwitchProtocol,
@@ -1170,5 +1170,5 @@ class Net::HTTPResponse
     '508' => Net::HTTPLoopDetected,
     '510' => Net::HTTPNotExtended,
     '511' => Net::HTTPNetworkAuthenticationRequired,
-  }
+  }.freeze
 end


### PR DESCRIPTION
Freeze `Net::HTTP::SSL_IVNAMES`, `Net::HTTPResponse::CODE_CLASS_TO_OBJ` and `Net::HTTPResponse::CODE_TO_OBJ` to improve Ractor compatibility.

This change allows the following code to work:

```ruby
Ractor.new {
  uri = URI.parse('http://example.com')
  http = Net::HTTP.new(uri.host, uri.port)
  http.open_timeout = nil
  http.read_timeout = nil
  http.get('/index.html')
}
```

---

Possibilities are that this patch breaks code which modify these constants. I have quickly skimmed over GitHub Code Search and have found only one instance where `CODE_TO_OBJ` is mutated, from 17-year-old code:
https://github.com/tolsen/rubydav/blob/62776abc293073da894b08c22d76952c918525c6/lib/rubydav/webdav.rb#L267

`rubydav` already needs a number of modifications to run under Ruby 3.4.1 even without this patch, so I think this change won't introduce additional major damage.