### PR TITLE
Don't set content type by default

### DIFF
--- a/lib/net/http/generic_request.rb
+++ b/lib/net/http/generic_request.rb
@@ -260,7 +260,6 @@ class Net::HTTPGenericRequest
   def send_request_with_body(sock, ver, path, body)
     self.content_length = body.bytesize
     delete 'Transfer-Encoding'
-    supply_default_content_type
     write_header sock, ver, path
     wait_for_continue sock, ver if sock.continue_timeout
     sock.write body
@@ -271,7 +270,6 @@ class Net::HTTPGenericRequest
       raise ArgumentError,
           "Content-Length not given and Transfer-Encoding is not `chunked'"
     end
-    supply_default_content_type
     write_header sock, ver, path
     wait_for_continue sock, ver if sock.continue_timeout
     if chunked?
@@ -373,12 +371,6 @@ class Net::HTTPGenericRequest
     buf.clear
   end
 
-  def supply_default_content_type
-    return if content_type()
-    warn 'net/http: Content-Type did not set; using application/x-www-form-urlencoded', uplevel: 1 if $VERBOSE
-    set_content_type 'application/x-www-form-urlencoded'
-  end
-
   ##
   # Waits up to the continue timeout for a response from the server provided
   # we're speaking HTTP 1.1 and are expecting a 100-continue response.
@@ -411,4 +403,3 @@ class Net::HTTPGenericRequest
   end
 
 end
-


### PR DESCRIPTION
Fixes https://github.com/ruby/net-http/issues/205