### PR TITLE
Allow a URL String for shorthand methods

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -819,7 +819,7 @@ module Net   #:nodoc:
           return http.request_get(path, &block)
         }
       else
-        uri = uri_or_host
+        uri = URI(uri_or_host)
         headers = path_or_headers
         start(uri.hostname, uri.port,
               :use_ssl => uri.scheme == 'https') {|http|
@@ -830,7 +830,7 @@ module Net   #:nodoc:
 
     # Posts data to a host; returns a Net::HTTPResponse object.
     #
-    # Argument +url+ must be a URL;
+    # Argument +url+ must be a URI;
     # argument +data+ must be a string:
     #
     #   _uri = uri.dup
@@ -855,6 +855,7 @@ module Net   #:nodoc:
     # - Net::HTTP#post: convenience method for \HTTP method +POST+.
     #
     def HTTP.post(url, data, header = nil)
+      url = URI(url)
       start(url.hostname, url.port,
             :use_ssl => url.scheme == 'https' ) {|http|
         http.post(url, data, header)
@@ -882,6 +883,7 @@ module Net   #:nodoc:
     #   }
     #
     def HTTP.post_form(url, params)
+      url = URI(url)
       req = Post.new(url)
       req.form_data = params
       req.basic_auth url.user, url.password if url.user
@@ -893,7 +895,7 @@ module Net   #:nodoc:
 
     # Sends a PUT request to the server; returns a Net::HTTPResponse object.
     #
-    # Argument +url+ must be a URL;
+    # Argument +url+ must be a URI;
     # argument +data+ must be a string:
     #
     #   _uri = uri.dup
@@ -918,6 +920,7 @@ module Net   #:nodoc:
     # - Net::HTTP#put: convenience method for \HTTP method +PUT+.
     #
     def HTTP.put(url, data, header = nil)
+      url = URI(url)
       start(url.hostname, url.port,
             :use_ssl => url.scheme == 'https' ) {|http|
         http.put(url, data, header)

--- a/test/net/http/test_http.rb
+++ b/test/net/http/test_http.rb
@@ -243,14 +243,11 @@ class TestNetHTTP < Test::Unit::TestCase
   end
 
   def test_failure_message_includes_failed_domain_and_port
-    # hostname to be included in the error message
-    host = Struct.new(:to_s).new("<example>")
-    port = 2119
-    # hack to let TCPSocket.open fail
-    def host.to_str; raise SocketError, "open failure"; end
-    uri = Struct.new(:scheme, :hostname, :port).new("http", host, port)
-    assert_raise_with_message(SocketError, /#{host}:#{port}/) do
-      TestNetHTTPUtils.clean_http_proxy_env{ Net::HTTP.get(uri) }
+    begin
+      Net::HTTP.get(URI.parse("http://example.invalid"))
+      fail "should have raised"
+    rescue => e
+      assert_includes e.message, "example.invalid:80"
     end
   end
 


### PR DESCRIPTION
In short, this allows `Net::HTTP.get("http://example.com")` instead of `Net::HTTP.get(URI("http://example.com"))`.