### PR TITLE
preventing hang when TCPSocket readable, but no app-data is available

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -2495,10 +2495,17 @@ module Net   #:nodoc:
           debug 'Conn close because of keep_alive_timeout'
           @socket.close
           connect
-        elsif @socket.io.to_io.wait_readable(0) && @socket.eof?
-          debug "Conn close because of EOF"
-          @socket.close
-          connect
+        elsif @socket.io.to_io.wait_readable(0)
+          # Check for EOF without blocking.
+          # With TLS 1.3, servers may send NewSessionTicket after responses,
+          # making the socket appear readable when only handshake data is
+          # pending. Using eof? here would block waiting for app data.
+          # See: https://bugs.ruby-lang.org/issues/19017
+          if eof_without_blocking?
+            debug "Conn close because of EOF"
+            @socket.close
+            connect
+          end
         end
       end
 
@@ -2525,6 +2532,21 @@ module Net   #:nodoc:
         debug 'Conn close'
         @socket.close
       end
+    end
+
+    def eof_without_blocking?
+      result = @socket.io.read_nonblock(1, exception: false)
+      case result
+      when nil
+        true
+      when :wait_readable, :wait_writable
+        false
+      when String
+        @socket.io.ungetc(result)
+        false
+      end
+    rescue EOFError
+      true
     end
 
     def keep_alive?(req, res)


### PR DESCRIPTION
eof? is a blocking read that times out when no application data is available - it should not be used as a readiness probe

 
