### PR TITLE
CI: Pin power_assert to v2 as power_assert v3 has dropped support for Ruby < 3.1.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 gem "rake"
 gem "test-unit"
 gem "test-unit-ruby-core"
+gem "power_assert", "~> 2.0" if RUBY_VERSION < '3.1' # https://github.com/ruby/power_assert/pull/61
 gem "webrick"


### PR DESCRIPTION
This Pull Request pins power_assert to v2.x, as power_assert has dropped support for Ruby < 3.1.

Since power_assert v3.0.0 has dropped support for Ruby 3.1 and earlier, but its gemspec does not specify `required_ruby_version`, the following error occurs in CI.
(Even if `required_ruby_version` is added in power_assert 3.0.1, Ruby 3.1 and earlier would still install version 3.0.0, so pinning to power_assert v2.x remains necessary.)

- https://github.com/ruby/power_assert/pull/57
- https://github.com/ruby/power_assert/pull/61

```sh
Run rake test
D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/gems/2.7.0/gems/power_assert-3.0.0/lib/power_assert/parser.rb:106: warning: Pattern matching is experimental, and the behavior may change in future versions of Ruby!
D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/gems/2.7.0/gems/power_assert-3.0.0/lib/power_assert/parser.rb:106: warning: Pattern matching is experimental, and the behavior may change in future versions of Ruby!
D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/win32/registry.rb:416:in `private_class_method': undefined method `new' for class `#<Class:Win32::Registry>' (NameError)
Did you mean?  next
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/win32/registry.rb:416:in `<class:Registry>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/win32/registry.rb:74:in `<module:Win32>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/win32/registry.rb:4:in `<top (required)>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/win32/resolv.rb:7:in `<top (required)>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/resolv.rb:171:in `<class:Hosts>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/resolv.rb:168:in `<class:Resolv>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/resolv.rb:38:in `<top (required)>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/net-http/net-http/lib/net/http.rb:25:in `<top (required)>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/net-http/net-http/test/net/http/test_buffered_io.rb:3:in `<top (required)>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/gems/2.7.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/gems/2.7.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb:6:in `select'
	from D:/a/_temp/rubyinstaller-2.7.8-1-x64/lib/ruby/gems/2.7.0/gems/rake-13.3.1/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1)
```
https://github.com/taketo1113/net-http/actions/runs/19091270166/job/54542337643#step:5:26