### PR TITLE
Replace Ruby 3.5 with Ruby 4.0

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -2587,7 +2587,7 @@ module Net   #:nodoc:
     alias_method :D, :debug
   end
 
-  # for backward compatibility until Ruby 3.5
+  # for backward compatibility until Ruby 4.0
   # https://bugs.ruby-lang.org/issues/20900
   # https://github.com/bblimke/webmock/pull/1081
   HTTPSession = HTTP


### PR DESCRIPTION
This commit updates the Ruby version in the error message to follow the commit in Ruby master branch. https://github.com/ruby/ruby/commit/6d81969b475262aba251e99b518181bdf7c5a523