### PR TITLE
Freeze more constants for Ractor compatibility

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1531,7 +1531,7 @@ module Net   #:nodoc:
       :verify_depth,
       :verify_mode,
       :verify_hostname,
-    ] # :nodoc:
+    ].freeze # :nodoc:
 
     SSL_IVNAMES = SSL_ATTRIBUTES.map { |a| "@#{a}".to_sym }.freeze # :nodoc:
 
@@ -2428,7 +2428,7 @@ module Net   #:nodoc:
 
     # :stopdoc:
 
-    IDEMPOTENT_METHODS_ = %w/GET HEAD PUT DELETE OPTIONS TRACE/ # :nodoc:
+    IDEMPOTENT_METHODS_ = %w/GET HEAD PUT DELETE OPTIONS TRACE/.freeze # :nodoc:
 
     def transport_request(req)
       count = 0


### PR DESCRIPTION
Freeze `Net::HTTP::SSL_ATTRIBUTES` and `IDEMPOTENT_METHODS_`. Both constants have been marked as `:nodoc:`.

Together with https://github.com/ruby/openssl/issues/521, this enables HTTPS clients in non-main Ractors on Ruby 4.0.

This applies on top of https://github.com/ruby/net-http/pull/255