### PR TITLE
Raise `Net::OpenTimeout` when `TCPSocket.open` raises `IO::TimeoutError`.

### DIFF
--- a/lib/net/http.rb
+++ b/lib/net/http.rb
@@ -1676,7 +1676,9 @@ module Net   #:nodoc:
       begin
         s = timeouted_connect(conn_addr, conn_port)
       rescue => e
-        e = Net::OpenTimeout.new(e) if e.is_a?(Errno::ETIMEDOUT) # for compatibility with previous versions
+        if (defined?(IO::TimeoutError) && e.is_a?(IO::TimeoutError)) || e.is_a?(Errno::ETIMEDOUT)  # for compatibility with previous versions
+          e = Net::OpenTimeout.new(e)
+        end
         raise e, "Failed to open TCP connection to " +
           "#{conn_addr}:#{conn_port} (#{e.message})"
       end


### PR DESCRIPTION
With the changes in https://github.com/ruby/ruby/pull/15602, `TCPSocket.open` now raises `IO::TimeoutError` when a user-specified timeout occurs. This change updates #connect to handle this case accordingly.