### PR TITLE
test: refactor assert to pass with nil as well

### DIFF
--- a/test/net/http/test_https.rb
+++ b/test/net/http/test_https.rb
@@ -148,7 +148,7 @@ class TestNetHTTPS < Test::Unit::TestCase
     http.get("/")
 
     socket = http.instance_variable_get(:@socket).io
-    assert_equal false, socket.session_reused?, "NOTE: OpenSSL library version is #{OpenSSL::OPENSSL_LIBRARY_VERSION}"
+    assert !socket.session_reused?, "NOTE: OpenSSL library version is #{OpenSSL::OPENSSL_LIBRARY_VERSION}"
 
     http.finish
   end


### PR DESCRIPTION
JRuby doesn't report session re-use and returns `nil`.

We're trying to run *net-http*'s tests as part of CI for **jruby-openssl** and this is the only failure we have.

It's a similar (test-only) change that was done a while back: https://github.com/ruby/net-http/pull/52/