### PR TITLE
Handle quoted content-type charset parameter values

### DIFF
--- a/lib/net/http/header.rb
+++ b/lib/net/http/header.rb
@@ -773,8 +773,16 @@ module Net::HTTPHeader
     list = self['Content-Type'].to_s.split(';')
     list.shift
     list.each do |param|
-      k, v = *param.split('=', 2)
-      result[k.strip] = v.strip
+      k, v = param.split('=', 2)
+      k.strip!
+      v.strip!
+      v.gsub!(/\A"(.*?)(?<!\\)"\z/) do
+        v2 = $1
+        v2.gsub!(/\\(.)/, '\1')
+        v2
+      end
+      v.strip!
+      result[k] = v
     end
     result
   end

--- a/test/net/http/test_httpheader.rb
+++ b/test/net/http/test_httpheader.rb
@@ -466,6 +466,8 @@ class HTTPHeaderTest < Test::Unit::TestCase
     assert_equal({'charset' => 'iso-2022-jp'}, @c.type_params)
     @c.content_type = 'text'
     assert_equal({}, @c.type_params)
+    @c['content-type'] = 'text/html; charset="UTF\-8"'
+    assert_equal({'charset' => 'UTF-8'}, @c.type_params)
   end
 
   def test_set_content_type


### PR DESCRIPTION
Additionally, as all related strings are new objects, use ! methods to reduce allocations.

Remove unnecessary * before param.split, as param.split already returns an array.

Fixes #267